### PR TITLE
Fix line height of posts/comments containing emoji

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react-dom": "^17.0.0",
         "axios": "^0.24.0",
         "date-fns": "^2.26.0",
+        "emoji-regex": "^10.0.1",
         "linkify-plugin-ticket": "^3.0.4",
         "linkify-react": "^3.0.4",
         "linkifyjs": "^3.0.5",
@@ -6485,9 +6486,9 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.1.tgz",
-      "integrity": "sha512-117l1H6U4X3Krn+MrzYrL57d5H7siRHWraBs7s+LjRuFK7Fe7hJqnJ0skWlinqsycVLU5YAo6L8CsEYQ0V5prg=="
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.0.1.tgz",
+      "integrity": "sha512-cLuZzriSWVE+rllzeq4zpUEoCPfYEbQ6ZVhIq+ed6ynWST7Bw9XnOr+bKWgCup4paq72DI21gw9M3aaFkm4HAw=="
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -7014,6 +7015,11 @@
       "engines": {
         "node": ">=6.0"
       }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.22.0",
@@ -26123,9 +26129,9 @@
       "integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ=="
     },
     "emoji-regex": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.1.tgz",
-      "integrity": "sha512-117l1H6U4X3Krn+MrzYrL57d5H7siRHWraBs7s+LjRuFK7Fe7hJqnJ0skWlinqsycVLU5YAo6L8CsEYQ0V5prg=="
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.0.1.tgz",
+      "integrity": "sha512-cLuZzriSWVE+rllzeq4zpUEoCPfYEbQ6ZVhIq+ed6ynWST7Bw9XnOr+bKWgCup4paq72DI21gw9M3aaFkm4HAw=="
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -26559,6 +26565,11 @@
             "@babel/runtime": "^7.10.2",
             "@babel/runtime-corejs3": "^7.10.2"
           }
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
         }
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "@types/react-dom": "^17.0.0",
     "axios": "^0.24.0",
     "date-fns": "^2.26.0",
+    "emoji-regex": "^10.0.1",
     "linkify-plugin-ticket": "^3.0.4",
     "linkify-react": "^3.0.4",
     "linkifyjs": "^3.0.5",

--- a/client/src/components/feeds/UserContent.css
+++ b/client/src/components/feeds/UserContent.css
@@ -22,3 +22,9 @@
 .PostRef:not(:hover) {
   text-decoration: none;
 }
+
+.UserContentEmoji {
+  line-height: 1em;
+  position: relative;
+  top: 0.1em;
+}

--- a/client/src/components/feeds/UserContent.tsx
+++ b/client/src/components/feeds/UserContent.tsx
@@ -4,10 +4,36 @@ import Linkify from "linkify-react";
 import "linkify-plugin-ticket";
 
 import "./UserContent.css";
+import makeEmojiRegex from "emoji-regex";
+const emojiRegex = makeEmojiRegex();
 
 interface UserContentProps {
-  children: React.ReactNode;
+  children: string;
   showContent: boolean;
+}
+
+function replaceEmoji(text: string): React.ReactChild[] {
+  const matches = text.matchAll(emojiRegex);
+
+  const children: React.ReactChild[] = [];
+  let lastIndex = 0;
+  for (const match of matches) {
+    const emoji = match[0];
+    const index = match.index!;
+    if (index > lastIndex) {
+      children.push(text.slice(lastIndex, index));
+    }
+    children.push(
+      <span className="UserContentEmoji" key={index}>
+        {emoji}
+      </span>
+    );
+    lastIndex = index + emoji.length;
+  }
+  if (lastIndex < text.length) {
+    children.push(text.slice(lastIndex));
+  }
+  return children;
 }
 
 function UserContent(props: UserContentProps) {
@@ -25,7 +51,7 @@ function UserContent(props: UserContentProps) {
         onClick={() => setShowContent(true)}
         title={showContent ? "" : "Click to reveal"}
       >
-        {props.children}
+        {replaceEmoji(props.children)}
       </p>
     </Linkify>
   );

--- a/client/src/components/feeds/post/comments/ContextThread.tsx
+++ b/client/src/components/feeds/post/comments/ContextThread.tsx
@@ -50,8 +50,8 @@ function ContextThread(props: ContextThreadProps) {
               </div>
               <div className="ContextThreadReplyText">
                 <UserContent showContent={true}>
-                  {props.thread.parentComment.content.substring(0, 10)}
-                  {props.thread.parentComment.content.length > 10 ? "…" : ""}
+                  {props.thread.parentComment.content.substring(0, 10) +
+                    (props.thread.parentComment.content.length > 10 ? "…" : "")}
                 </UserContent>
               </div>
             </>


### PR DESCRIPTION
Example: https://dearblueno.net/post/1444

Before:
<img width="735" alt="Screenshot_2022-03-31 09 48 19" src="https://user-images.githubusercontent.com/25517624/161070768-29289411-07db-4ad5-a873-e6dce1eb28ed.png">

After:
<img width="744" alt="Screenshot_2022-03-31 09 48 39" src="https://user-images.githubusercontent.com/25517624/161070857-19376318-9544-407a-b44c-bf5e99706209.png">


I shifted the emoji down by `0.1em` to center them, but haven’t tested this magic number on non-Apple platforms.
