### PR TITLE
Block clicks on blurred links

### DIFF
--- a/client/src/components/feeds/UserContent.css
+++ b/client/src/components/feeds/UserContent.css
@@ -17,6 +17,7 @@
 
 .UserContentHidden a {
   pointer-events: none;
+  color: inherit;
 }
 
 .PostRef {

--- a/client/src/components/feeds/UserContent.css
+++ b/client/src/components/feeds/UserContent.css
@@ -15,6 +15,10 @@
   filter: blur(3px);
 }
 
+.UserContentHidden a {
+  pointer-events: none;
+}
+
 .PostRef {
   color: inherit;
   font-weight: 550;


### PR DESCRIPTION
Example: http://localhost:3000/post/3080 / https://dearblueno.net/post/3080 contains a reference to post #&zwnj;2909.

Currently, it’s possible to click on that post reference by accident, redirecting you to a different post instead of revealing the current post. This is especially risky to users since they can’t necessarily review the link before clicking on it, and blurred posts are more likely to have inappropriate/otherwise uncomfortable links on them than non-blurred posts.