### PR TITLE
Add a setting for the default home feed sort

### DIFF
--- a/client/src/components/feeds/MainFeed.tsx
+++ b/client/src/components/feeds/MainFeed.tsx
@@ -2,7 +2,7 @@ import { getPosts } from "gateways/PostGateway";
 import Feed from "components/feeds/ReactQueryFeed";
 import Post from "components/post/Post";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { parseSortQueryParams } from "components/header/mainfeed/MainFeedHeader";
+import { parseSortQueryParamsOnly } from "components/header/mainfeed/MainFeedHeader";
 import { useRouter } from "next/router";
 import useUser from "hooks/useUser";
 import IUser from "types/IUser";
@@ -27,22 +27,25 @@ function MainFeedWrapper() {
 
 function MainFeed({ user }: { user: IUser | undefined }) {
   const router = useRouter();
-  const sort = parseSortQueryParams(router.query.sort, router.query.of, user);
+  const sort = parseSortQueryParamsOnly(router.query.sort, router.query.of);
   const fetchPosts = ({ pageParam = 1 }) =>
     getPosts(pageParam, sort).then((res) => res.payload ?? []);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =
-    useInfiniteQuery(["posts", sort], fetchPosts, {
-      // initialData:
-      //   sort === "hot"
-      //     ? { pages: [props.initialPosts], pageParams: [1] }
-      //     : undefined,
-      getNextPageParam: (lastPage, pages) => {
-        if (lastPage.length === 0) {
-          return undefined;
-        }
-        return pages.length + 1;
-      },
-    });
+    useInfiniteQuery(
+      [
+        "posts",
+        sort === (user?.settings.homeFeedSort ?? "hot") ? "default" : sort,
+      ],
+      fetchPosts,
+      {
+        getNextPageParam: (lastPage, pages) => {
+          if (lastPage.length === 0) {
+            return undefined;
+          }
+          return pages.length + 1;
+        },
+      }
+    );
 
   return (
     <Feed

--- a/client/src/components/feeds/MainFeed.tsx
+++ b/client/src/components/feeds/MainFeed.tsx
@@ -5,9 +5,27 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { parseSortQueryParams } from "components/header/mainfeed/MainFeedHeader";
 import { useRouter } from "next/router";
 import useUser from "hooks/useUser";
+import IUser from "types/IUser";
 
-function MainFeed() {
-  const { user } = useUser();
+function MainFeedWrapper() {
+  const { user, isLoadingUser } = useUser();
+  if (isLoadingUser) {
+    return (
+      <Feed
+        getMore={() => Promise.reject("not a real feed")}
+        status="loading"
+        isFetchingNextPage
+        hasNextPage={undefined}
+        animated
+      >
+        {[]}
+      </Feed>
+    );
+  }
+  return <MainFeed user={user} />;
+}
+
+function MainFeed({ user }: { user: IUser | undefined }) {
   const router = useRouter();
   const sort = parseSortQueryParams(router.query.sort, router.query.of, user);
   const fetchPosts = ({ pageParam = 1 }) =>
@@ -41,4 +59,4 @@ function MainFeed() {
   );
 }
 
-export default MainFeed;
+export default MainFeedWrapper;

--- a/client/src/components/feeds/MainFeed.tsx
+++ b/client/src/components/feeds/MainFeed.tsx
@@ -4,10 +4,12 @@ import Post from "components/post/Post";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { parseSortQueryParams } from "components/header/mainfeed/MainFeedHeader";
 import { useRouter } from "next/router";
+import useUser from "hooks/useUser";
 
 function MainFeed() {
+  const { user } = useUser();
   const router = useRouter();
-  const sort = parseSortQueryParams(router.query.sort, router.query.of);
+  const sort = parseSortQueryParams(router.query.sort, router.query.of, user);
   const fetchPosts = ({ pageParam = 1 }) =>
     getPosts(pageParam, sort).then((res) => res.payload ?? []);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =

--- a/client/src/components/feeds/MainFeed.tsx
+++ b/client/src/components/feeds/MainFeed.tsx
@@ -5,27 +5,9 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { parseSortQueryParamsOnly } from "components/header/mainfeed/MainFeedHeader";
 import { useRouter } from "next/router";
 import useUser from "hooks/useUser";
-import IUser from "types/IUser";
 
-function MainFeedWrapper() {
-  const { user, isLoadingUser } = useUser();
-  if (isLoadingUser) {
-    return (
-      <Feed
-        getMore={() => Promise.reject("not a real feed")}
-        status="loading"
-        isFetchingNextPage
-        hasNextPage={undefined}
-        animated
-      >
-        {[]}
-      </Feed>
-    );
-  }
-  return <MainFeed user={user} />;
-}
-
-function MainFeed({ user }: { user: IUser | undefined }) {
+function MainFeed() {
+  const { user } = useUser();
   const router = useRouter();
   const sort = parseSortQueryParamsOnly(router.query.sort, router.query.of);
   const fetchPosts = ({ pageParam = 1 }) =>
@@ -62,4 +44,4 @@ function MainFeed({ user }: { user: IUser | undefined }) {
   );
 }
 
-export default MainFeedWrapper;
+export default MainFeed;

--- a/client/src/components/header/mainfeed/MainFeedHeader.tsx
+++ b/client/src/components/header/mainfeed/MainFeedHeader.tsx
@@ -1,12 +1,15 @@
 import styles from "./MainFeedHeader.module.scss";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/router";
+import useUser from "hooks/useUser";
+import IUser from "types/IUser";
 
 export type SortType = "hot" | "topWeek" | "topMonth" | "new" | "topAllTime";
 
 export const parseSortQueryParams = (
   sort: string | string[] | undefined,
-  of: string | string[] | undefined
+  of: string | string[] | undefined,
+  user: IUser | undefined
 ): SortType => {
   if (sort) {
     const sortType = sort as string;
@@ -22,27 +25,69 @@ export const parseSortQueryParams = (
       return sortType;
     }
   }
-  return "hot";
+  return user?.settings.homeFeedSort ?? "hot";
 };
 
 export default function MainFeedHeader() {
-  const hotRef = useRef<HTMLHeadingElement>(null);
-  const topRef = useRef<HTMLHeadingElement>(null);
-  const newRef = useRef<HTMLHeadingElement>(null);
-  const underlineRef = useRef<HTMLSpanElement>(null);
+  const { user } = useUser();
   const router = useRouter();
-  const [choosingTop, setChoosingTop] = useState<boolean>(false);
-
   const parseSortQueryParamsCallback = useCallback(
-    (): SortType => parseSortQueryParams(router.query.sort, router.query.of),
-    [router.query.sort, router.query.of]
+    (): SortType =>
+      parseSortQueryParams(router.query.sort, router.query.of, user),
+    [router.query.sort, router.query.of, user]
   );
-
-  const [sort, setSort] = useState<SortType>(parseSortQueryParamsCallback());
 
   useEffect(() => {
     setSort(parseSortQueryParamsCallback());
   }, [parseSortQueryParamsCallback]);
+
+  const [sort, setSort] = useState<SortType>(parseSortQueryParamsCallback());
+
+  const [oldSort, setOldSort] = useState<SortType>(sort);
+  useEffect(() => {
+    if (sort === oldSort) return;
+    setOldSort(sort);
+
+    if (sort === (user?.settings.homeFeedSort ?? "hot")) {
+      void router.push("/");
+      return;
+    }
+
+    switch (sort) {
+      case "hot":
+        void router.push("/?sort=hot");
+        break;
+      case "new":
+        void router.push("/?sort=new");
+        break;
+
+      case "topWeek":
+        void router.push("/?sort=top&of=week");
+        break;
+      case "topMonth":
+        void router.push("/?sort=top&of=month");
+        break;
+      case "topAllTime":
+        void router.push("/?sort=top&of=alltime");
+        break;
+    }
+  }, [sort, oldSort, router, user?.settings.homeFeedSort]);
+
+  return <FeedPicker sort={sort} setSort={setSort} />;
+}
+
+export function FeedPicker({
+  sort,
+  setSort,
+}: {
+  sort: SortType;
+  setSort: React.Dispatch<React.SetStateAction<SortType>>;
+}) {
+  const hotRef = useRef<HTMLHeadingElement>(null);
+  const topRef = useRef<HTMLHeadingElement>(null);
+  const newRef = useRef<HTMLHeadingElement>(null);
+  const underlineRef = useRef<HTMLSpanElement>(null);
+  const [choosingTop, setChoosingTop] = useState<boolean>(false);
 
   const underlinedRef = useMemo(() => {
     if (sort === "hot") {
@@ -134,10 +179,8 @@ export default function MainFeedHeader() {
           if (choosingTop) {
             setSort("topWeek");
             setChoosingTop(false);
-            void router.push("/?sort=top&of=week");
           } else {
             setSort("hot");
-            void router.push("/");
           }
         }}
       >
@@ -153,7 +196,6 @@ export default function MainFeedHeader() {
           } else {
             setSort("topMonth");
             setChoosingTop(false);
-            void router.push("/?sort=top&of=month");
           }
         }}
       >
@@ -167,10 +209,8 @@ export default function MainFeedHeader() {
           if (choosingTop) {
             setSort("topAllTime");
             setChoosingTop(false);
-            void router.push("/?sort=top&of=alltime");
           } else {
             setSort("new");
-            void router.push("/?sort=new");
           }
         }}
       >

--- a/client/src/components/header/mainfeed/MainFeedHeader.tsx
+++ b/client/src/components/header/mainfeed/MainFeedHeader.tsx
@@ -6,11 +6,10 @@ import IUser from "types/IUser";
 
 export type SortType = "hot" | "topWeek" | "topMonth" | "new" | "topAllTime";
 
-export const parseSortQueryParams = (
+export const parseSortQueryParamsOnly = (
   sort: string | string[] | undefined,
-  of: string | string[] | undefined,
-  user: IUser | undefined
-): SortType => {
+  of: string | string[] | undefined
+): SortType | "default" => {
   if (sort) {
     const sortType = sort as string;
     if (sortType === "top") {
@@ -25,7 +24,15 @@ export const parseSortQueryParams = (
       return sortType;
     }
   }
-  return user?.settings.homeFeedSort ?? "hot";
+  return "default";
+};
+export const parseSortQueryParams = (
+  sort: string | string[] | undefined,
+  of: string | string[] | undefined,
+  user: IUser | undefined
+): SortType => {
+  const type = parseSortQueryParamsOnly(sort, of);
+  return type === "default" ? user?.settings.homeFeedSort ?? "hot" : type;
 };
 
 export default function MainFeedHeader() {
@@ -48,7 +55,7 @@ export default function MainFeedHeader() {
     if (sort === oldSort) return;
     setOldSort(sort);
 
-    if (sort === (user?.settings.homeFeedSort ?? "hot")) {
+    if (sort === "default") {
       void router.push("/");
       return;
     }

--- a/client/src/components/header/mainfeed/MainFeedHeader.tsx
+++ b/client/src/components/header/mainfeed/MainFeedHeader.tsx
@@ -55,7 +55,7 @@ export default function MainFeedHeader() {
     if (sort === oldSort) return;
     setOldSort(sort);
 
-    if (sort === "default") {
+    if (sort === (user?.settings.homeFeedSort ?? "hot")) {
       void router.push("/");
       return;
     }

--- a/client/src/components/post/reactions/ReactionBar.tsx
+++ b/client/src/components/post/reactions/ReactionBar.tsx
@@ -66,7 +66,7 @@ function ReactionBar(props: ReactionBarProps) {
   const [order, setOrder] = useState<number[]>();
   const queryClient = useQueryClient();
   const router = useRouter();
-  const sort = parseSortQueryParams(router.query.sort, router.query.of);
+  const sort = parseSortQueryParams(router.query.sort, router.query.of, user);
 
   const unsortedReactions = props.reactions.map((list, index) => ({
     type: index,

--- a/client/src/gateways/PostGateway.ts
+++ b/client/src/gateways/PostGateway.ts
@@ -11,7 +11,7 @@ import {
 
 export async function getPosts(
   page?: number,
-  sort?: "hot" | "new" | "topAllTime" | "topWeek" | "topMonth"
+  sort?: "hot" | "new" | "topAllTime" | "topWeek" | "topMonth" | "default"
 ): Promise<IResponse<IPost[]>> {
   try {
     const response = await axios.get("/posts", {

--- a/client/src/gateways/UserGateway.ts
+++ b/client/src/gateways/UserGateway.ts
@@ -130,12 +130,10 @@ export async function markAllNotificationsAsRead(): Promise<
 }
 
 export async function updateSettings(
-  autoSubscribe: boolean
+  newSettings: IUser["settings"]
 ): Promise<IResponse<IUser>> {
   try {
-    const response = await axios.put(`/user/settings`, {
-      autoSubscribe,
-    });
+    const response = await axios.put(`/user/settings`, newSettings);
     return successfulResponse(response.data);
   } catch (error: unknown) {
     return failureResponse(error as string);

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import GenericProfileButton from "components/profile/buttons/GenericProfileButton";
 import { updateSettings } from "gateways/UserGateway";
 import toast from "react-hot-toast";
+import { FeedPicker } from "components/header/mainfeed/MainFeedHeader";
 
 const SettingsPage: NextPage = () => {
   return (
@@ -24,10 +25,16 @@ function SettingsPageMain() {
   const [autoSubInput, setAutoSubInput] = useState(
     user?.settings.autoSubscribe ?? false
   );
+  const [homeFeedSortInput, setHomeFeedSortInput] = useState(
+    user?.settings.homeFeedSort ?? "hot"
+  );
 
   const handleSettingsEdit = () => {
-    if (user && autoSubInput !== user.settings.autoSubscribe) {
-      updateSettings(autoSubInput)
+    if (user) {
+      updateSettings({
+        autoSubscribe: autoSubInput,
+        homeFeedSort: homeFeedSortInput,
+      })
         .then((response) => {
           if (response.success) {
             toast.success("Settings updated successfully!");
@@ -45,18 +52,32 @@ function SettingsPageMain() {
     <div className={styles.SettingsPage}>
       {user ? (
         <>
-          <h3 className={styles.SettingsHeader}>Notifications</h3>
+          <div className={styles.SettingsContainer}>
+            <h3 className={styles.SettingsHeader}>Notifications</h3>
+            <label className={styles.AutoSubBox}>
+              <input
+                type="checkbox"
+                checked={autoSubInput}
+                onChange={() => setAutoSubInput(!autoSubInput)}
+                className={styles.AutoSubInput}
+              />
+              <p>Auto-Sub On Public Comment</p>
+            </label>
+          </div>
           <div
-            className={styles.AutoSubBox}
-            onClick={() => setAutoSubInput(!autoSubInput)}
+            className={styles.SettingsContainer}
+            style={{ flexDirection: "row" }}
           >
-            <input
-              type="checkbox"
-              checked={autoSubInput}
-              onChange={() => setAutoSubInput(!autoSubInput)}
-              className={styles.AutoSubInput}
+            <h3
+              className={styles.SettingsHeader}
+              style={{ flexShrink: 0, alignSelf: "center" }}
+            >
+              Default Home Feed
+            </h3>
+            <FeedPicker
+              sort={homeFeedSortInput}
+              setSort={setHomeFeedSortInput}
             />
-            <p>Auto-Sub On Public Comment</p>
           </div>
           <div className={styles.SaveAndCancelButtons}>
             <div className={styles.ContainerOne}>

--- a/client/src/styles/SettingsPage.module.scss
+++ b/client/src/styles/SettingsPage.module.scss
@@ -21,8 +21,6 @@
   gap: 0.5rem;
   align-items: center;
   width: 100%;
-  margin-bottom: -1rem;
-  margin-top: -0.5rem;
   cursor: pointer;
 }
 
@@ -30,6 +28,16 @@
   font-weight: 600;
   user-select: none;
   cursor: default;
+}
+
+.HomePageBox {
+  align-self: flex-start;
+}
+
+.SettingsContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .SaveAndCancelButtons {

--- a/client/src/types/IUser.ts
+++ b/client/src/types/IUser.ts
@@ -34,6 +34,7 @@ export default interface IUser extends IBasicUser {
   subscriptions: string[];
   settings: {
     autoSubscribe: boolean;
+    homeFeedSort: "hot" | "new" | "topMonth" | "topWeek" | "topAllTime";
   };
 }
 

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -137,6 +137,11 @@ const UserSchema = new Schema({
       type: Boolean,
       default: true,
     },
+    homeFeedSort: {
+      type: String,
+      default: "hot",
+      enum: ["hot", "new", "topMonth", "topWeek", "topAllTime"],
+    }
   },
 });
 
@@ -176,8 +181,11 @@ export interface IUser extends IBasicUser {
   subscriptions: any[];
   settings: {
     autoSubscribe: boolean;
+    homeFeedSort: "hot" | "new" | "topMonth" | "topWeek" | "topAllTime";
   };
 }
+
+export const homeFeedSorts = ["hot", "new", "topMonth", "topWeek", "topAllTime"] as const;
 
 type INotification =
   | INewCommentNotification

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -141,7 +141,7 @@ const UserSchema = new Schema({
       type: String,
       default: "hot",
       enum: ["hot", "new", "topMonth", "topWeek", "topAllTime"],
-    }
+    },
   },
 });
 
@@ -185,7 +185,13 @@ export interface IUser extends IBasicUser {
   };
 }
 
-export const homeFeedSorts = ["hot", "new", "topMonth", "topWeek", "topAllTime"] as const;
+export const homeFeedSorts = [
+  "hot",
+  "new",
+  "topMonth",
+  "topWeek",
+  "topAllTime",
+] as const;
 
 type INotification =
   | INewCommentNotification

--- a/server/src/routes/posts.ts
+++ b/server/src/routes/posts.ts
@@ -15,7 +15,7 @@ postRouter.get(
   optionalAuth,
   query("page").default(1).isInt({ min: 1 }),
   query("sort")
-    .default("new")
+    .default("default")
     .isIn(["new", "topWeek", "topMonth", "topAllTime", "hot", "default"]),
   validate,
   async (req, res) => {

--- a/server/src/routes/user.ts
+++ b/server/src/routes/user.ts
@@ -315,7 +315,7 @@ userRouter.put(
   "/settings",
   authCheck,
   body("autoSubscribe").isBoolean(),
-  body('homeFeedSort').custom(value => homeFeedSorts.includes(value)),
+  body("homeFeedSort").custom((value) => homeFeedSorts.includes(value)),
   validate,
   async (req, res) => {
     const user = req.user as IUser;

--- a/server/src/routes/user.ts
+++ b/server/src/routes/user.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { body, param, query } from "express-validator";
 import Comment from "../models/Comment";
 import { authCheck, modCheck } from "../middleware/auth";
-import User, { IUser } from "../models/User";
+import User, { homeFeedSorts, IUser } from "../models/User";
 import Post from "../models/Post";
 import { validate } from "../middleware/validate";
 import cleanSensitivePost from "../config/cleanSensitivePost";
@@ -315,14 +315,15 @@ userRouter.put(
   "/settings",
   authCheck,
   body("autoSubscribe").isBoolean(),
+  body('homeFeedSort').custom(value => homeFeedSorts.includes(value)),
   validate,
   async (req, res) => {
     const user = req.user as IUser;
-    const { autoSubscribe } = req.body;
+    const { autoSubscribe, homeFeedSort } = req.body;
 
     const newUser = await User.findByIdAndUpdate(
       user._id,
-      { settings: { autoSubscribe } },
+      { settings: { autoSubscribe, homeFeedSort } },
       { new: true }
     );
 

--- a/server/src/routes/user.ts
+++ b/server/src/routes/user.ts
@@ -315,7 +315,7 @@ userRouter.put(
   "/settings",
   authCheck,
   body("autoSubscribe").isBoolean(),
-  body("homeFeedSort").custom((value) => homeFeedSorts.includes(value)),
+  body("homeFeedSort").isIn(homeFeedSorts),
   validate,
   async (req, res) => {
     const user = req.user as IUser;

--- a/server/src/tests/integration/posts.spec.ts
+++ b/server/src/tests/integration/posts.spec.ts
@@ -59,7 +59,7 @@ describe("Posts", () => {
         approved: true,
       }).save();
 
-      const res = await request(app).get("/posts").expect(200);
+      const res = await request(app).get("/posts?sort=new").expect(200);
       expect(res.body).toHaveLength(2);
 
       expect(res.body[1].content).toBe("This is a test post");
@@ -81,13 +81,13 @@ describe("Posts", () => {
         approved: true,
       }).save();
 
-      const res = await request(app).get("/posts?page=1").expect(200);
+      const res = await request(app).get("/posts?page=1&sort=new").expect(200);
       expect(res.body).toHaveLength(1);
 
       expect(res.body[0].content).toBe("This is a test post");
       expect(res.body[0].postNumber).toBe(1);
 
-      const res2 = await request(app).get("/posts?page=2").expect(200);
+      const res2 = await request(app).get("/posts?page=2&sort=new").expect(200);
       expect(res2.body).toHaveLength(0);
     });
 
@@ -96,7 +96,7 @@ describe("Posts", () => {
         content: "This is a test post",
       }).save();
 
-      const res = await request(app).get("/posts").expect(200);
+      const res = await request(app).get("/posts?sort=new").expect(200);
       expect(res.body).toHaveLength(0);
     });
 
@@ -113,7 +113,7 @@ describe("Posts", () => {
       }
       await Promise.all(promises);
 
-      const res = await request(app).get("/posts").expect(200);
+      const res = await request(app).get("/posts?sort=new").expect(200);
       expect(res.body).toHaveLength(10);
     });
 
@@ -148,7 +148,7 @@ describe("Posts", () => {
       post.comments.push(comment2._id);
       await post.save();
 
-      const res = await request(app).get("/posts").expect(200);
+      const res = await request(app).get("/posts?sort=new").expect(200);
       expect(res.body[0].comments).toHaveLength(1);
       expect(res.body[0].comments[0].content).toBe("This is a test comment");
       expect(res.body[0].comments[0].commentNumber).toBe(1);
@@ -164,12 +164,15 @@ describe("Posts", () => {
       });
       await post.save();
 
-      const res = await request(app).get("/posts").expect(200);
+      const res = await request(app).get("/posts?sort=new").expect(200);
       expect(res.body[0].reactions[0]).toHaveLength(1);
       expect(res.body[0].reactions[0][0].name).toBeUndefined();
       expect(res.body[0].reactions[0][0]).toBe("anon");
 
-      const res2 = await request(app).get("/posts").send({ user }).expect(200);
+      const res2 = await request(app)
+        .get("/posts?sort=new")
+        .send({ user })
+        .expect(200);
       expect(res2.body[0].reactions[0]).toHaveLength(1);
       expect(res2.body[0].reactions[0][0]).toBe(String(user._id));
     });
@@ -195,7 +198,7 @@ describe("Posts", () => {
       post.comments.push(comment._id);
       await post.save();
 
-      const res = await request(app).get("/posts").expect(200);
+      const res = await request(app).get("/posts?sort=new").expect(200);
       expect(res.body[0].comments[0].author.moderator).toBeUndefined();
       expect(res.body[0].comments[0].author.lastLoggedIn).toBeUndefined();
       expect(res.body[0].comments[0].author.email).toBeUndefined();
@@ -210,7 +213,7 @@ describe("Posts", () => {
       });
       await post.save();
 
-      const res = await request(app).get("/posts").expect(200);
+      const res = await request(app).get("/posts?sort=new").expect(200);
       expect(res.body[0].approvedBy).toBeUndefined();
     });
 
@@ -230,7 +233,7 @@ describe("Posts", () => {
       });
       await post2.save();
 
-      const res = await request(app).get("/posts").expect(200);
+      const res = await request(app).get("/posts?sort=new").expect(200);
 
       expect(res.body[0].content).toBe("This is a test post");
       expect(res.body[0].postNumber).toBe(1);
@@ -406,7 +409,7 @@ describe("Posts", () => {
       });
       await post.save();
 
-      const res = await request(app).get("/posts").expect(200);
+      const res = await request(app).get("/posts?sort=new").expect(200);
       expect(res.body[0].imageUrl).toBe("https://i.imgur.com/Ydhgl4K.jpg");
     });
 
@@ -416,18 +419,21 @@ describe("Posts", () => {
         postNumber: 1,
         approved: true,
         hotScore: 100,
+        approvedTime: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000),
       });
       const post2 = new Post({
         content: "This is another test post",
         postNumber: 2,
         approved: true,
         hotScore: 50,
+        approvedTime: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000),
       });
       const post3 = new Post({
         content: "This is a third test post",
         postNumber: 3,
         approved: true,
         hotScore: 75,
+        approvedTime: new Date(),
       });
       await Promise.all([post.save(), post2.save(), post3.save()]);
 
@@ -453,6 +459,7 @@ describe("Posts", () => {
         approved: true,
         hotScore: 50,
         score: 100,
+        approvedTime: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000),
       });
       const post3 = new Post({
         content: "This is a third test post",

--- a/server/src/tests/integration/user.spec.ts
+++ b/server/src/tests/integration/user.spec.ts
@@ -610,16 +610,28 @@ describe("User", () => {
         .expect(400);
     });
 
+    it("should return 400 if invalid home feed sort is sent", async () => {
+      await request(app)
+        .put("/user/settings")
+        .send({
+          user,
+          settings: { autoSubscribe: false, homeFeedSort: "worst" },
+        })
+        .expect(400);
+    });
+
     it("should update user settings", async () => {
       expect(user.settings.autoSubscribe).toBe(true);
+      expect(user.settings.homeFeedSort).toBe("hot");
 
       await request(app)
         .put("/user/settings")
-        .send({ user, autoSubscribe: false })
+        .send({ user, autoSubscribe: false, homeFeedSort: "new" })
         .expect(200);
 
       const newUser = await User.findById(user._id);
       expect(newUser?.settings.autoSubscribe).toBe(false);
+      expect(newUser?.settings.homeFeedSort).toBe("new");
     });
   });
 

--- a/server/src/tests/integration/user.spec.ts
+++ b/server/src/tests/integration/user.spec.ts
@@ -606,7 +606,7 @@ describe("User", () => {
     it("should return 400 if invalid settings are sent", async () => {
       await request(app)
         .put("/user/settings")
-        .send({ user, settings: { invalid: "settings" } })
+        .send({ user, invalid: "settings" })
         .expect(400);
     });
 
@@ -615,7 +615,8 @@ describe("User", () => {
         .put("/user/settings")
         .send({
           user,
-          settings: { autoSubscribe: false, homeFeedSort: "worst" },
+          autoSubscribe: false,
+          homeFeedSort: "worst",
         })
         .expect(400);
     });


### PR DESCRIPTION
The settings page now has a copy of the feed selector on the home page…

<img width="772" alt="Screenshot_2022-09-20 10 25 41" src="https://user-images.githubusercontent.com/25517624/191284523-c495d057-da1a-4185-8692-13c22ac419d4.png">

…that changes what you see when you visit `dearblueno.net/`. The toggle on the home page will navigate to `/` when you select your default, and all feed sorting options remain accessible.

The one small thing is that the selector always seems to start at “hot” and then later switch to the desired feed when loading the page (but you can see a similar issue at https://www.dearblueno.net/?sort=new, so I’m not terribly worried about this)