### PR TITLE
Remove autofocus from image and text submit on mobile

### DIFF
--- a/client/src/components/submit/ImageSubmit.tsx
+++ b/client/src/components/submit/ImageSubmit.tsx
@@ -68,7 +68,6 @@ function ImageSubmit(props: ImageSubmitProps) {
           id="TextBox"
           className={styles.TextBox}
           name="TextBox"
-          autoFocus={true}
         ></textarea>
         <div className={styles.ImageUploadContainer}>
           <ImageUpload

--- a/client/src/components/submit/ImageSubmit.tsx
+++ b/client/src/components/submit/ImageSubmit.tsx
@@ -5,6 +5,7 @@ import { Dispatch, SetStateAction, useState } from "react";
 import ImageUpload from "./ImageUpload";
 import useUser from "hooks/useUser";
 import { loginBrown } from "gateways/AuthGateway";
+import { useIsMobile } from "hooks/is-mobile";
 
 interface ImageSubmitProps {
   setSubmitted: Dispatch<SetStateAction<boolean>>;
@@ -12,6 +13,7 @@ interface ImageSubmitProps {
 
 function ImageSubmit(props: ImageSubmitProps) {
   const [imageURL, setImageURL] = useState<string | undefined>();
+  const isMobile = useIsMobile();
   const { user } = useUser();
   const submitPost = (text: string) => {
     if (text.length > 100) {
@@ -68,6 +70,7 @@ function ImageSubmit(props: ImageSubmitProps) {
           id="TextBox"
           className={styles.TextBox}
           name="TextBox"
+          autoFocus={isMobile ? false : true}
         ></textarea>
         <div className={styles.ImageUploadContainer}>
           <ImageUpload

--- a/client/src/components/submit/TextSubmit.tsx
+++ b/client/src/components/submit/TextSubmit.tsx
@@ -3,12 +3,14 @@ import GoogleFormOption from "./GoogleFormOption";
 import { createPost } from "../../gateways/PostGateway";
 import toast from "react-hot-toast";
 import { Dispatch, SetStateAction } from "react";
+import { useIsMobile } from "hooks/is-mobile";
 
 interface TextSubmitProps {
   setSubmitted: Dispatch<SetStateAction<boolean>>;
 }
 
 function TextSubmit(props: TextSubmitProps) {
+  const isMobile = useIsMobile();
   const submitPost = (text: string) => {
     if (text.length > 5000) {
       toast.error(`Post is ${text.length - 5000} characters too long`);
@@ -39,6 +41,7 @@ function TextSubmit(props: TextSubmitProps) {
             id="TextBox"
             className={styles.TextBox}
             name="TextBox"
+            autoFocus={isMobile ? false : true}
           ></textarea>
           <div className={styles.SubmitBoxFooter}>
             <GoogleFormOption />

--- a/client/src/components/submit/TextSubmit.tsx
+++ b/client/src/components/submit/TextSubmit.tsx
@@ -39,7 +39,6 @@ function TextSubmit(props: TextSubmitProps) {
             id="TextBox"
             className={styles.TextBox}
             name="TextBox"
-            autoFocus={true}
           ></textarea>
           <div className={styles.SubmitBoxFooter}>
             <GoogleFormOption />


### PR DESCRIPTION
Autofocusing on mobile causes the entire post selection bar to be obstructed, diminishing the ability of discovery.