### PR TITLE
👎

### DIFF
--- a/client/src/components/post/reactions/ReactionBar.tsx
+++ b/client/src/components/post/reactions/ReactionBar.tsx
@@ -12,6 +12,8 @@ import LikeIcon from "images/like.svg";
 import LikeBWIcon from "images/likeBW.svg";
 import SurpriseIcon from "images/surprise.svg";
 import SurpriseBWIcon from "images/surpriseBW.svg";
+import DislikeIcon from "images/dislike.svg";
+import DislikeBWIcon from "images/dislikeBW.svg";
 import { useState, useMemo } from "react";
 import { reactToComment, reactToPost } from "gateways/PostGateway";
 import useUser from "hooks/useUser";
@@ -41,6 +43,7 @@ enum ReactionType {
   CRY,
   ANGRY,
   SURPRISE,
+  DISLIKE,
 }
 
 interface Reaction {
@@ -54,11 +57,24 @@ interface ReactionRequest {
   newValue: boolean;
 }
 
+const baseReactionOrder: ReactionType[] = [
+  ReactionType.LIKE,
+  ReactionType.DISLIKE,
+  ReactionType.HEART,
+  ReactionType.LAUGH,
+  ReactionType.CRY,
+  ReactionType.ANGRY,
+  ReactionType.SURPRISE,
+];
+
 const reactionCompare = (a: Reaction, b: Reaction) => {
-  if (a.reactors.length === 0 || b.reactors.length === 0) {
-    return b.reactors.length - a.reactors.length || a.type - b.type;
+  if (
+    (a.reactors.length === 0 || b.reactors.length === 0) &&
+    a.type === b.type
+  ) {
+    return b.reactors.length - a.reactors.length;
   }
-  return a.type - b.type;
+  return baseReactionOrder.indexOf(a.type) - baseReactionOrder.indexOf(b.type);
 };
 
 function ReactionBar(props: ReactionBarProps) {
@@ -97,6 +113,7 @@ function ReactionBar(props: ReactionBarProps) {
       [CryIcon, CryBWIcon],
       [AngryIcon, AngryBWIcon],
       [SurpriseIcon, SurpriseBWIcon],
+      [DislikeIcon, DislikeBWIcon],
     ],
     []
   );

--- a/client/src/images/dislike.svg
+++ b/client/src/images/dislike.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 61.5 66" style="enable-background:new 0 0 61.5 66;" xml:space="preserve">
+<style type="text/css">
+	.st0{display:none;}
+	.st1{fill:#FF9D9D;stroke:#000000;stroke-width:4;stroke-miterlimit:10;}
+</style>
+<g id="Layer_1_00000048469623031685519850000013933544635851126712_" class="st0">
+
+		<image style="display:inline;overflow:visible;enable-background:new    ;" width="178" height="178" xlink:href="ACFC0F6B.jpeg"  transform="matrix(0.3456 0 0 0.3456 0 4.3142)">
+	</image>
+</g>
+<g id="Layer_2_00000088104400790103823680000013869840743415021467_">
+	<path class="st1" d="M7.7,60.5C6,58.7,5.3,56.7,4.7,55c-0.5-1.6-1.1-3.6-0.2-16.2c0.5-7.5,0.1-1.9,0.5-7.5s8.1-11.9,16-22.7
+		c0.9-2,2.5-6,5.5-6.5c0.2,0,1.9-0.3,3.2,0.8C30,3.1,31.1,4.1,31.1,7C31,12.5,27,17.9,24,24c-0.3,0.5-1,1.7-0.3,2.6s1.7,0.7,2.3,0.7
+		c4.7-0.1,7.1-0.1,7.1-0.1C34,27,48,27.4,49.5,27.5s4,1,4.1,2.5c0.1,1-1.3,1.8-1.7,3.5c-0.1,0.3-0.2,1.1,0.2,1.8
+		c0.1,0.1,0.1,0.2,0.2,0.2c0.3,0.3,0.7,0.4,1.7,1.2c1.1,0.8,1.6,1.2,1.8,1.7c1.2,1.5,0,3.1,0,3.1s-1.3,0.9-2.5,2.5
+		c-0.6,0.8-0.7,1.4-0.6,1.8c0,0.2,0.1,0.5,0.5,0.9c1,1.3,1.9,1.2,2.5,2.1c0.3,0.6,0.4,1.4,0.3,2c-0.3,0.9-1.1,1.5-2.7,2.5
+		c-1.1,0.7-1.8,0.9-2.1,1.7c-0.1,0.2-0.3,0.7-0.2,1.2c0.1,0.9,0.8,1.1,1.3,1.8c0.7,1.1,0.4,2.8-0.2,3.8c-0.8,1.2-2.4,1.5-3.1,1.6
+		C39,64,38.5,64,31.8,63.9S11.9,65.1,7.7,60.5z" style="transform: rotate(0.5turn); transform-origin: center;"/>
+</g>
+</svg>

--- a/client/src/images/dislikeBW.svg
+++ b/client/src/images/dislikeBW.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 61.5 66" style="enable-background:new 0 0 61.5 66;" xml:space="preserve">
+<style type="text/css">
+	.st0{display:none;}
+	.st1{fill:none;stroke:#000000;stroke-width:4;stroke-miterlimit:10;}
+</style>
+<g id="Layer_1_00000089534910328658932200000003193119185794215841_" class="st0">
+
+		<image style="display:inline;overflow:visible;enable-background:new    ;" width="178" height="178" xlink:href="40F4C6A6.jpeg"  transform="matrix(0.3456 0 0 0.3456 0 4.3142)">
+	</image>
+</g>
+<g id="Layer_2_00000115485176967780635420000011699373271583695796_">
+	<path class="st1" d="M7.7,60.5C6,58.7,5.3,56.7,4.7,55c-0.5-1.6-1.1-3.6-0.2-16.2c0.5-7.5,0.1-1.9,0.5-7.5s8.1-11.9,16-22.7
+		c0.9-2,2.5-6,5.5-6.5c0.2,0,1.9-0.3,3.2,0.8C30,3.1,31.1,4.1,31.1,7C31,12.5,27,17.9,24,24c-0.3,0.5-1,1.7-0.3,2.6s1.7,0.7,2.3,0.7
+		c4.7-0.1,7.1-0.1,7.1-0.1C34,27,48,27.4,49.5,27.5s4,1,4.1,2.5c0.1,1-1.3,1.8-1.7,3.5c-0.1,0.3-0.2,1.1,0.2,1.8
+		c0.1,0.1,0.1,0.2,0.2,0.2c0.3,0.3,0.7,0.4,1.7,1.2c1.1,0.8,1.6,1.2,1.8,1.7c1.2,1.5,0,3.1,0,3.1s-1.3,0.9-2.5,2.5
+		c-0.6,0.8-0.7,1.4-0.6,1.8c0,0.2,0.1,0.5,0.5,0.9c1,1.3,1.9,1.2,2.5,2.1c0.3,0.6,0.4,1.4,0.3,2c-0.3,0.9-1.1,1.5-2.7,2.5
+		c-1.1,0.7-1.8,0.9-2.1,1.7c-0.1,0.2-0.3,0.7-0.2,1.2c0.1,0.9,0.8,1.1,1.3,1.8c0.7,1.1,0.4,2.8-0.2,3.8c-0.8,1.2-2.4,1.5-3.1,1.6
+		C39,64,38.5,64,31.8,63.9S11.9,65.1,7.7,60.5z" style="transform: rotate(0.5turn); transform-origin: center;" />
+</g>
+</svg>

--- a/server/src/routes/posts.ts
+++ b/server/src/routes/posts.ts
@@ -317,7 +317,7 @@ postRouter.put(
 postRouter.put(
   "/:id/react",
   authCheck,
-  body("reaction").isInt({ min: 1, max: 6 }),
+  body("reaction").isInt({ min: 1, max: 7 }),
   body("state").toBoolean(),
   param("id").isInt({ min: 1 }),
   validate,


### PR DESCRIPTION
<img width="763" alt="Screenshot_2022-10-03 12 30 41" src="https://user-images.githubusercontent.com/25517624/193630361-6c1f3a4c-f258-4a6a-a9a8-3f635f4edd95.png">

This does make the reaction button shrinkage on mobile worse, not sure how to resolve that:
<img width="322" alt="Screenshot_2022-10-03 12 31 11" src="https://user-images.githubusercontent.com/25517624/193630514-47cb74d2-4413-4aa9-8f30-7a20d220f690.png">

- [ ] Update “react to comment” endpoint