### PR TITLE
Don’t prompt to reset display name if it hasn’t been edited

### DIFF
--- a/client/src/components/profile/ProfileBox.tsx
+++ b/client/src/components/profile/ProfileBox.tsx
@@ -184,16 +184,19 @@ function ProfileBox(props: ProfileBoxProps) {
     <div className={styles.ProfileBox}>
       <div className={styles.LeftColumn}>
         <ProfilePicture
+          hidden={editing}
           link={props.profileUser ? props.profileUser.profilePicture : ""}
         ></ProfilePicture>
-        <ProfileName
-          name={
-            props.profileUser
-              ? props.profileUser.displayName ?? props.profileUser.name
-              : ""
-          }
-          pronouns={props.profileUser ? props.profileUser.pronouns : ""}
-        />
+        {!editing && (
+          <ProfileName
+            name={
+              props.profileUser
+                ? props.profileUser.displayName ?? props.profileUser.name
+                : ""
+            }
+            pronouns={props.profileUser ? props.profileUser.pronouns : ""}
+          />
+        )}
         {ownProfile && !editing && (
           <GenericProfileButton click={() => setEditing(true)} text={"Edit"} />
         )}

--- a/client/src/components/profile/left_column/ProfilePersonalInfo.tsx
+++ b/client/src/components/profile/left_column/ProfilePersonalInfo.tsx
@@ -122,7 +122,7 @@ function ProfilePersonalInfo(props: ProfilePersonalInfoProps) {
                       e.target.value &&
                       e.target.value !== content
                     ) {
-                      setNameToRevertTo(content);
+                      setNameToRevertTo(content ?? "");
                     }
                   }}
                 ></input>

--- a/client/src/components/profile/left_column/ProfilePersonalInfo.tsx
+++ b/client/src/components/profile/left_column/ProfilePersonalInfo.tsx
@@ -32,7 +32,8 @@ function ProfilePersonalInfo(props: ProfilePersonalInfoProps) {
     "Concentration",
   ];
 
-  const [isOpen, setIsOpen] = useState(false);
+  // null if not showing the dialog
+  const [nameToRevertTo, setNameToRevertTo] = useState<string | null>(null);
 
   if (!props.editing && props.contents.every((content) => !content)) {
     return null;
@@ -42,8 +43,8 @@ function ProfilePersonalInfo(props: ProfilePersonalInfoProps) {
     <div>
       <DialogOverlay
         style={{ background: "hsla(0, 0%, 0%, 0.2)" }}
-        isOpen={isOpen}
-        onDismiss={() => setIsOpen(false)}
+        isOpen={nameToRevertTo !== null}
+        onDismiss={() => setNameToRevertTo(null)}
       >
         <DialogContent
           aria-label="Preferred Name Popup"
@@ -71,10 +72,10 @@ function ProfilePersonalInfo(props: ProfilePersonalInfoProps) {
               <button
                 className={styles.PopupAction}
                 onClick={() => {
-                  setIsOpen(false);
-                  if (props.refs[0].current) {
-                    props.refs[0].current.value = "";
+                  if (props.refs[0].current && nameToRevertTo) {
+                    props.refs[0].current.value = nameToRevertTo;
                   }
+                  setNameToRevertTo(null);
                 }}
                 tabIndex={-1}
               >
@@ -83,7 +84,7 @@ function ProfilePersonalInfo(props: ProfilePersonalInfoProps) {
               <button
                 className={styles.PopupAction}
                 onClick={() => {
-                  setIsOpen(false);
+                  setNameToRevertTo(null);
                 }}
                 tabIndex={-1}
               >
@@ -115,12 +116,13 @@ function ProfilePersonalInfo(props: ProfilePersonalInfoProps) {
                   className={styles.PersonalInfoInput}
                   defaultValue={content}
                   placeholder={placeholders[index]}
-                  onBlur={() => {
-                    const bool = props.refs[index].current
-                      ? props.refs[index].current?.value
-                      : "";
-                    if (placeholders[index] === "Preferred Name" && bool) {
-                      setIsOpen(true);
+                  onBlur={(e) => {
+                    if (
+                      placeholders[index] === "Preferred Name" &&
+                      e.target.value &&
+                      e.target.value !== content
+                    ) {
+                      setNameToRevertTo(content);
                     }
                   }}
                 ></input>

--- a/client/src/components/profile/left_column/ProfilePicture.tsx
+++ b/client/src/components/profile/left_column/ProfilePicture.tsx
@@ -3,12 +3,13 @@ import styles from "./ProfilePicture.module.scss";
 
 interface ProfilePictureProps {
   link: string;
+  hidden: boolean;
 }
 
 function ProfilePicture(props: ProfilePictureProps) {
   const src = props.link.replace("=s96-c", "=s1024-c");
   return (
-    <div className={styles.ProfilePicture}>
+    <div className={styles.ProfilePicture} hidden={props.hidden}>
       <Image
         className={styles.ProfilePictureImage}
         src={src}

--- a/client/src/styles/globals.scss
+++ b/client/src/styles/globals.scss
@@ -19,6 +19,10 @@ html {
   scrollbar-width: none;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 body::-webkit-scrollbar {
   display: none;
 }


### PR DESCRIPTION
Currently, tabbing away from the display name field while you have a custom display name set will ask you if you’re sure you want to set a custom display name and then reset it if you click “cancel.” The new change will always revert back to the initial value if you click cancel, and will check whether the value is different from the initial value before opening the modal.

Bonus: hide the name/pronouns + profile photo sections while editing to reduce layout shift and avoid discrepancy between current name/pronouns and updated ones