### PR TITLE
Fixes #40; force comment array update on prop update in `CommentSection`

### DIFF
--- a/client/src/components/feeds/SearchFeed.tsx
+++ b/client/src/components/feeds/SearchFeed.tsx
@@ -29,8 +29,8 @@ function SearchFeed(props: SearchFeedProps) {
     <>
       {props.results.length > 0 && (
         <Feed user={props.user} getMore={getMore} animated={false}>
-          {props.results.slice(0, pageNumber * 10).map((post, index) => (
-            <Post key={index} post={post} />
+          {props.results.slice(0, pageNumber * 10).map((post) => (
+            <Post key={post._id} post={post} />
           ))}
         </Feed>
       )}

--- a/client/src/components/post/comments/CommentSection.tsx
+++ b/client/src/components/post/comments/CommentSection.tsx
@@ -2,7 +2,7 @@ import styles from "./CommentSection.module.scss";
 import Thread from "./Thread";
 import IComment from "types/IComment";
 import NewCommentBox from "./new_comment/NewCommentBox";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import ViewMoreButton from "./ViewMoreButton";
 
 export interface CommentSectionProps {
@@ -95,10 +95,13 @@ const sortComments = (commentList: IThread[]) => {
 };
 
 function CommentSection(props: CommentSectionProps) {
-  const threads = nestComments(convertToThreads(props.comments));
-  calculateScores(threads);
-  sortComments(threads);
-  const [comments, setComments] = useState<IThread[]>(threads);
+  const [comments, setComments] = useState<IThread[]>([]);
+  useEffect(() => {
+    const threads = nestComments(convertToThreads(props.comments));
+    calculateScores(threads);
+    sortComments(threads);
+    setComments(threads);
+  }, [props.comments]);
   const firstThree = comments.slice(0, 3);
   const rest = comments.slice(3);
   const [showingAll, setShowingAll] = useState(false);

--- a/client/src/components/post/comments/CommentSection.tsx
+++ b/client/src/components/post/comments/CommentSection.tsx
@@ -2,7 +2,7 @@ import styles from "./CommentSection.module.scss";
 import Thread from "./Thread";
 import IComment from "types/IComment";
 import NewCommentBox from "./new_comment/NewCommentBox";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import ViewMoreButton from "./ViewMoreButton";
 
 export interface CommentSectionProps {
@@ -95,13 +95,10 @@ const sortComments = (commentList: IThread[]) => {
 };
 
 function CommentSection(props: CommentSectionProps) {
-  const [comments, setComments] = useState<IThread[]>([]);
-  useEffect(() => {
-    const threads = nestComments(convertToThreads(props.comments));
-    calculateScores(threads);
-    sortComments(threads);
-    setComments(threads);
-  }, [props.comments]);
+  const threads = nestComments(convertToThreads(props.comments));
+  calculateScores(threads);
+  sortComments(threads);
+  const [comments, setComments] = useState<IThread[]>(threads);
   const firstThree = comments.slice(0, 3);
   const rest = comments.slice(3);
   const [showingAll, setShowingAll] = useState(false);


### PR DESCRIPTION
This is really just a quick fix to the issue described in #40. Maybe some time in the future I'll have a stab at the search frontend as a whole. 

For one reason or another, `comments` in `CommentSection` would be stale despite prop update from `props.comments`, likely due to `useState` running async and updating *after* render. Wrapping all thread computation into a `useEffect` (which will trigger child component renders on recomputation via a call to `setComments`) seems to do the trick (unless anybody is morally opposed to what I have done). 