### PR TITLE
Add user blocking endpoints to backend api

### DIFF
--- a/client/src/gateways/UserGateway.ts
+++ b/client/src/gateways/UserGateway.ts
@@ -139,3 +139,21 @@ export async function updateSettings(
     return failureResponse(error as string);
   }
 }
+
+export async function blockUser(_id: string): Promise<IResponse<IUser>> {
+  try {
+    const response = await axios.post(`/user/block`, { id: _id });
+    return successfulResponse(response.data);
+  } catch (error: unknown) {
+    return failureResponse(error as string);
+  }
+}
+
+export async function unblockUser(_id: string): Promise<IResponse<IUser>> {
+  try {
+    const response = await axios.put(`/user/block`, { id: _id });
+    return successfulResponse(response.data);
+  } catch (error: unknown) {
+    return failureResponse(error as string);
+  }
+}

--- a/client/src/types/IUser.ts
+++ b/client/src/types/IUser.ts
@@ -32,6 +32,7 @@ export default interface IUser extends IBasicUser {
   notifications: INotification[];
   bookmarks: string[];
   subscriptions: string[];
+  blockedUsers: string[];
   settings: {
     autoSubscribe: boolean;
     homeFeedSort: "hot" | "new" | "topMonth" | "topWeek" | "topAllTime";

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -132,6 +132,12 @@ const UserSchema = new Schema({
       ref: "Post",
     },
   ],
+  blockedUsers: [
+    {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+    },
+  ],
   settings: {
     autoSubscribe: {
       type: Boolean,
@@ -179,6 +185,7 @@ export interface IUser extends IBasicUser {
   bookmarks: any[];
   notifications: INotification[];
   subscriptions: any[];
+  blockedUsers: any[];
   settings: {
     autoSubscribe: boolean;
     homeFeedSort: "hot" | "new" | "topMonth" | "topWeek" | "topAllTime";

--- a/server/src/routes/user.ts
+++ b/server/src/routes/user.ts
@@ -102,7 +102,7 @@ userRouter.get(
     })
       .limit(5)
       .select(
-        "-email -lastLoggedIn -moderator -bannedUntil -bookmarks -notifications -subscriptions -settings"
+        "-email -lastLoggedIn -moderator -bannedUntil -bookmarks -notifications -subscriptions -blockedUsers -settings"
       );
 
     if (users.length === 0) {
@@ -119,7 +119,7 @@ userRouter.get(
 userRouter.get("/:id", param("id").isMongoId(), validate, async (req, res) => {
   // Get user by id, remove sensitive information from the response
   const user = await User.findById(req.params.id).select(
-    "-email -lastLoggedIn -moderator -bannedUntil -bookmarks -notifications -subscriptions -settings"
+    "-email -lastLoggedIn -moderator -bannedUntil -bookmarks -notifications -subscriptions -blockedUsers -settings"
   );
   if (!user) {
     res.status(404).send("User not found");
@@ -324,6 +324,39 @@ userRouter.put(
     const newUser = await User.findByIdAndUpdate(
       user._id,
       { settings: { autoSubscribe, homeFeedSort } },
+      { new: true }
+    );
+
+    res.send(newUser);
+  }
+);
+
+// POST request that blocks a user
+// (Auth required)
+userRouter.post(
+  "/block",
+  authCheck,
+  body("id").isMongoId(),
+  validate,
+  async (req, res) => {
+    const user = req.user as IUser;
+    const { id } = req.body;
+
+    if (user.blockedUsers.includes(id)) {
+      res.status(400).send("User already blocked");
+      return;
+    }
+
+    const targetUser = await User.findById(id);
+    if (!targetUser) {
+      res.status(404).send("User not found");
+      return;
+    }
+
+    user.blockedUsers.push(id);
+    const newUser = await User.findByIdAndUpdate(
+      user._id,
+      { blockedUsers: user.blockedUsers },
       { new: true }
     );
 

--- a/server/src/routes/user.ts
+++ b/server/src/routes/user.ts
@@ -364,4 +364,31 @@ userRouter.post(
   }
 );
 
+// PUT request that unblocks a user
+// (Auth required)
+userRouter.put(
+  "/unblock",
+  authCheck,
+  body("id").isMongoId(),
+  validate,
+  async (req, res) => {
+    const user = req.user as IUser;
+    const { id } = req.body;
+
+    if (!user.blockedUsers.includes(id)) {
+      res.status(400).send("User not blocked");
+      return;
+    }
+
+    user.blockedUsers = user.blockedUsers.filter((userId) => userId !== id);
+    const newUser = await User.findByIdAndUpdate(
+      user._id,
+      { blockedUsers: user.blockedUsers },
+      { new: true }
+    );
+
+    res.send(newUser);
+  }
+);
+
 export default userRouter;

--- a/server/src/tests/integration/user.spec.ts
+++ b/server/src/tests/integration/user.spec.ts
@@ -636,6 +636,37 @@ describe("User", () => {
     });
   });
 
+  describe("POST /user/block", () => {
+    it("should return 401 if user is not logged in", async () => {
+      await request(app).post("/user/block").expect(401);
+    });
+
+    it("should return 404 if non-existent user is blocked", async () => {
+      await request(app)
+        .post("/user/block")
+        .send({ user, id: "5bb9e9f84186b222c8901149" })
+        .expect(404);
+    });
+
+    it("should block user", async () => {
+      await request(app)
+        .post("/user/block")
+        .send({ user, id: user._id })
+        .expect(200);
+
+      const user2 = await User.findById(user._id);
+      expect(user2?.blockedUsers).toContainEqual(user._id);
+
+      await request(app)
+        .post("/user/block")
+        .send({ user, id: user._id })
+        .expect(200);
+
+      const user3 = await User.findById(user._id);
+      expect(user3?.blockedUsers).toContainEqual(user._id);
+    });
+  });
+
   afterAll(async () => {
     await mongoose.connection.close();
     await mongo.stop();

--- a/server/src/tests/integration/user.spec.ts
+++ b/server/src/tests/integration/user.spec.ts
@@ -48,6 +48,12 @@ describe("User", () => {
       expect(response.body).not.toHaveProperty("user.email");
       expect(response.body).not.toHaveProperty("user.lastLoggedIn");
       expect(response.body).not.toHaveProperty("user.moderator");
+      expect(response.body).not.toHaveProperty("user.bannedUntil");
+      expect(response.body).not.toHaveProperty("user.bookmarks");
+      expect(response.body).not.toHaveProperty("user.notifications");
+      expect(response.body).not.toHaveProperty("user.subscriptions");
+      expect(response.body).not.toHaveProperty("user.blockedUsers");
+      expect(response.body).not.toHaveProperty("user.settings");
     });
   });
 
@@ -81,6 +87,12 @@ describe("User", () => {
       expect(searchedUser).not.toHaveProperty("email");
       expect(searchedUser).not.toHaveProperty("lastLoggedIn");
       expect(searchedUser).not.toHaveProperty("moderator");
+      expect(searchedUser).not.toHaveProperty("bannedUntil");
+      expect(searchedUser).not.toHaveProperty("bookmarks");
+      expect(searchedUser).not.toHaveProperty("notifications");
+      expect(searchedUser).not.toHaveProperty("subscriptions");
+      expect(searchedUser).not.toHaveProperty("blockedUsers");
+      expect(searchedUser).not.toHaveProperty("settings");
     });
   });
 


### PR DESCRIPTION
Contains backend functionality for blocking users. Note that the filtering out of blocked users will take place on the frontend -- no noticeable changes to the functionality are included in this PR. This also means this PR is not blocked by frontend implementation.

* Updates the user model (and associated types) to include an array of users called blockedUsers
* Implements two new endpoints: POST /user/block and PUT /user/unblock
* Adds associated tests for new endpoints
* Adds new gateways functions for new endpoints