### PR TITLE
Make hot feed infinite

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -58,7 +58,7 @@ authRouter.get("/google/callback", (req, res, next) => {
       if (loginErr) {
         return next(loginErr);
       }
-      res.redirect(url);
+      return res.redirect(url);
     });
   })(req, res, next);
 });

--- a/server/src/routes/posts.ts
+++ b/server/src/routes/posts.ts
@@ -72,20 +72,22 @@ postRouter.get(
       });
 
     // If reached the end of the hot feed, switch to the new feed
-    if (sort === "hot" && posts.length === 0) {
-      posts = await Post.find(filterOptions.new)
-        .sort(sortOptions.new)
-        .skip((page - 1) * 10)
-        .limit(10)
-        .select("-approvedBy -subscribers -score -hotScore")
-        .populate("comments")
-        .populate({
-          path: "comments",
-          populate: {
-            path: "author",
-            select: "name profilePicture badges displayName pronouns",
-          },
-        });
+    if (sort === "hot" && posts.length !== 10) {
+      posts = posts.concat(
+        await Post.find(filterOptions.new)
+          .sort(sortOptions.new)
+          .skip((page - 1) * 10 + posts.length)
+          .limit(10 - posts.length)
+          .select("-approvedBy -subscribers -score -hotScore")
+          .populate("comments")
+          .populate({
+            path: "comments",
+            populate: {
+              path: "author",
+              select: "name profilePicture badges displayName pronouns",
+            },
+          })
+      );
     }
 
     const cleanPosts = posts.map((post) =>

--- a/server/src/routes/posts.ts
+++ b/server/src/routes/posts.ts
@@ -57,7 +57,7 @@ postRouter.get(
     };
     const filterQuery = filterOptions[sort];
 
-    const posts = await Post.find(filterQuery)
+    let posts = await Post.find(filterQuery)
       .sort(sortQuery)
       .skip((page - 1) * 10)
       .limit(10)
@@ -70,6 +70,23 @@ postRouter.get(
           select: "name profilePicture badges displayName pronouns",
         },
       });
+
+    // If reached the end of the hot feed, switch to the new feed
+    if (sort === "hot" && posts.length === 0) {
+      posts = await Post.find(filterOptions.new)
+        .sort(sortOptions.new)
+        .skip((page - 1) * 10)
+        .limit(10)
+        .select("-approvedBy -subscribers -score -hotScore")
+        .populate("comments")
+        .populate({
+          path: "comments",
+          populate: {
+            path: "author",
+            select: "name profilePicture badges displayName pronouns",
+          },
+        });
+    }
 
     const cleanPosts = posts.map((post) =>
       cleanSensitivePost(post.toObject(), user)

--- a/server/src/tests/integration/posts.spec.ts
+++ b/server/src/tests/integration/posts.spec.ts
@@ -363,10 +363,11 @@ describe("Posts", () => {
       await Promise.all([post.save(), post2.save(), post3.save()]);
 
       const res = await request(app).get("/posts?sort=hot").expect(200);
-      expect(res.body).toHaveLength(2);
+      expect(res.body).toHaveLength(3);
 
       expect(res.body[0].postNumber).toBe(3);
       expect(res.body[1].postNumber).toBe(2);
+      expect(res.body[2].postNumber).toBe(1);
     });
 
     it("should sort by new", async () => {


### PR DESCRIPTION
Makes the "hot" sort feed infinite by appending the "new" sort feed after the hot feed ends.
Demo live on https://staging.dearblueno.net/

* The hot feed only includes posts from the last 7 days.
* Posts will switch back to purely chronological order after reaching the end of hot.
* The new feed will resume at the same spot (7 days old) when it is appended. The transition will be seamless (the frontend will still display hot).
* Entirely a backend addition (no frontend changes needed + backwards compatible).