### PR TITLE
Filter out posts with no post number from feeds

### DIFF
--- a/server/src/routes/posts.ts
+++ b/server/src/routes/posts.ts
@@ -40,18 +40,21 @@ postRouter.get(
     };
     const sortQuery = sortOptions[sort];
     const filterOptions = {
-      new: { approved: true },
+      new: { approved: true, postNumber: { $ne: null } },
       topWeek: {
         approved: true,
+        postNumber: { $ne: null },
         approvedTime: { $gte: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7) },
       },
       topMonth: {
         approved: true,
+        postNumber: { $ne: null },
         approvedTime: { $gte: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30) },
       },
-      topAllTime: { approved: true },
+      topAllTime: { approved: true, postNumber: { $ne: null } },
       hot: {
         approved: true,
+        postNumber: { $ne: null },
         approvedTime: { $gte: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7) },
       },
     };

--- a/server/src/tests/integration/posts.spec.ts
+++ b/server/src/tests/integration/posts.spec.ts
@@ -488,6 +488,19 @@ describe("Posts", () => {
       expect(res2.body[1].postNumber).toBe(3);
       expect(res2.body[2].postNumber).toBe(1);
     });
+
+    it("should not return posts with null postNumber", async () => {
+      const post = new Post({
+        content: "This is a test post",
+        approved: true,
+        hotScore: 100,
+        approvedTime: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000),
+      });
+      await post.save();
+
+      const res = await request(app).get("/posts").expect(200);
+      expect(res.body).toHaveLength(0);
+    });
   });
 
   describe("GET /posts/all", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Title should be declarative and use present tense, e.g. "Add feature" not "Added feature" -->

## Description
<!--- Describe your changes in detail -->
Previously, the only requirement for a post to show up in the homepage feeds was having `approved` set to `true`. Now, in addition, the post must have a non-null `postNumber` in order to show up in the main feed as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This prevents posts without a `postNumber` from showing up in the feed. This allows creating hidden posts only accessible from search, but not through the home feed.

## How this has been tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Added a new test to verify posts without postNumbers indeed don't show up in the feed. All existing tests passed without changes necessary.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I ran the linter and formatter before submitting the PR. (`npm run lint`)
- [x] My PR passes all existing tests and adds new tests where appropriate. (`npm test`)
- [x] I have updated the documentation if necessary.
