### PR TITLE
Add generated sitemap.txt

### DIFF
--- a/client/src/components/event/EventCard.tsx
+++ b/client/src/components/event/EventCard.tsx
@@ -129,7 +129,7 @@ export default function EventCard(props: EventCardProps) {
         }
       );
     } else {
-      toast.error((response.message as unknown as { message: string }).message);
+      toast.error(response.message);
     }
   };
 

--- a/client/src/components/post/Post.tsx
+++ b/client/src/components/post/Post.tsx
@@ -60,7 +60,7 @@ function Post(props: PostProps) {
       toast.success(`${action} #${props.post.postNumber}`);
       await refetchUser();
     } else {
-      toast.error((response.message as unknown as { message: string }).message);
+      toast.error(response.message);
       setIsSubscribed(!isSubscribed);
     }
   };
@@ -78,7 +78,7 @@ function Post(props: PostProps) {
       void queryClient.refetchQueries(["bookmarks"]);
       await refetchUser();
     } else {
-      toast.error((response.message as unknown as { message: string }).message);
+      toast.error(response.message);
       setIsBookmarked(initialIsBookmarked);
     }
   };

--- a/client/src/components/post/Post.tsx
+++ b/client/src/components/post/Post.tsx
@@ -87,7 +87,11 @@ function Post(props: PostProps) {
     <div className={styles.Post}>
       <div className={styles.PostHeader}>
         <div className={styles.PostHeaderLeft}>
-          <PostNumber number={props.post.postNumber} post={props.post} />
+          <PostNumber
+            number={props.post.postNumber}
+            post={props.post}
+            _id={props.post._id}
+          />
           {props.post.verifiedBrown && (
             <RiShieldCheckFill
               className={styles.VerifiedBrown}

--- a/client/src/components/post/ReportReview.tsx
+++ b/client/src/components/post/ReportReview.tsx
@@ -44,7 +44,7 @@ export default function ReportReview(props: ReportReviewProps) {
         );
       }
     } else {
-      toast.error((response.message as unknown as { message: string }).message);
+      toast.error(response.message);
     }
   };
 

--- a/client/src/components/post/comments/ContextThread.tsx
+++ b/client/src/components/post/comments/ContextThread.tsx
@@ -39,7 +39,7 @@ function ContextThread(props: ContextThreadProps) {
         }
       );
     } else {
-      toast.error((response.message as unknown as { message: string }).message);
+      toast.error(response.message);
     }
   };
 

--- a/client/src/components/post/comments/comment_header/CommentMenuButton.tsx
+++ b/client/src/components/post/comments/comment_header/CommentMenuButton.tsx
@@ -116,10 +116,7 @@ function CommentMenuButton(props: CommentMenuButtonProps) {
                     if (response.success) {
                       toast.success("Comment reported");
                     } else {
-                      toast.error(
-                        (response.message as unknown as { message: string })
-                          .message
-                      );
+                      toast.error(response.message);
                       console.log(response);
                     }
                     closePopup();

--- a/client/src/components/post/comments/new_comment/NewCommentBox.tsx
+++ b/client/src/components/post/comments/new_comment/NewCommentBox.tsx
@@ -81,9 +81,7 @@ function NewCommentBox(props: NewCommentBoxProps) {
           });
           return true;
         }
-        toast.error(
-          (response.message as unknown as { message: string }).message
-        );
+        toast.error(response.message);
         return false;
       }
       return false;

--- a/client/src/components/post/moderator/ApproveOrDeny.tsx
+++ b/client/src/components/post/moderator/ApproveOrDeny.tsx
@@ -53,9 +53,7 @@ function ApproveOrDeny(props: ApproveOrDenyProps) {
               }
             );
           } else {
-            toast.error(
-              (response.message as unknown as { message: string }).message
-            );
+            toast.error(response.message);
           }
         };
       case "comment":
@@ -86,9 +84,7 @@ function ApproveOrDeny(props: ApproveOrDenyProps) {
               }
             );
           } else {
-            toast.error(
-              (response.message as unknown as { message: string }).message
-            );
+            toast.error(response.message);
           }
         };
     }

--- a/client/src/components/post/moderator/CommentReview.tsx
+++ b/client/src/components/post/moderator/CommentReview.tsx
@@ -34,7 +34,7 @@ function CommentReview(props: CommentReviewProps) {
         }
       );
     } else {
-      toast.error((response.message as unknown as { message: string }).message);
+      toast.error(response.message);
     }
   };
 

--- a/client/src/components/post/reactions/ReactionButton.tsx
+++ b/client/src/components/post/reactions/ReactionButton.tsx
@@ -32,9 +32,7 @@ function ReactionButton(props: ReactionButtonProps) {
             result
               .then((response) => {
                 if (!response.success) {
-                  toast.error(
-                    (response.message as unknown as { message: string }).message
-                  );
+                  toast.error(response.message);
                 }
               })
               .catch(() => toast.error("Uh oh, something went wrong"));

--- a/client/src/components/profile/ProfileBox.tsx
+++ b/client/src/components/profile/ProfileBox.tsx
@@ -158,9 +158,7 @@ function ProfileBox(props: ProfileBoxProps) {
               console.error(error);
             });
         } else {
-          toast.error(
-            (response.message as unknown as { message: string }).message
-          );
+          toast.error(response.message);
         }
       })
       .catch((error) => {

--- a/client/src/components/submit/ImageSubmit.tsx
+++ b/client/src/components/submit/ImageSubmit.tsx
@@ -29,9 +29,7 @@ function ImageSubmit(props: ImageSubmitProps) {
           props.setSubmitted(true);
           toast.success("Post submitted for approval!");
         } else {
-          toast.error(
-            (response.message as unknown as { message: string }).message
-          );
+          toast.error(response.message);
         }
       })
       .catch((error) => {

--- a/client/src/components/submit/TextSubmit.tsx
+++ b/client/src/components/submit/TextSubmit.tsx
@@ -22,9 +22,7 @@ function TextSubmit(props: TextSubmitProps) {
           props.setSubmitted(true);
           toast.success("Post submitted for approval!");
         } else {
-          toast.error(
-            (response.message as unknown as { message: string }).message
-          );
+          toast.error(response.message);
         }
       })
       .catch((error) => {

--- a/client/src/gateways/AuthGateway.ts
+++ b/client/src/gateways/AuthGateway.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import IUser from "../types/IUser";
 import {
   failureResponse,
+  failureResponseFromError,
   IResponse,
   successfulResponse,
 } from "./GatewayResponses";
@@ -17,7 +18,7 @@ export async function loadAuth(): Promise<IResponse<IUser>> {
       return failureResponse("Not logged in");
     }
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 

--- a/client/src/gateways/EventGateway.ts
+++ b/client/src/gateways/EventGateway.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import IEvent, { IEventReactions } from "../types/IEvent";
 import {
-  failureResponse,
+  failureResponseFromError,
   IResponse,
   successfulResponse,
 } from "./GatewayResponses";
@@ -11,7 +11,7 @@ export async function getEvents(page: number): Promise<IResponse<IEvent[]>> {
     const response = await axios.get(`/events?page=${page}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -21,7 +21,7 @@ export async function getAllEvents(page: number): Promise<IResponse<IEvent[]>> {
     const response = await axios.get(`/events/all?page=${page}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -33,7 +33,7 @@ export async function getModFeedEvents(
     const response = await axios.get(`/events/mod-feed?page=${page}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -42,7 +42,7 @@ export async function getEvent(id: string): Promise<IResponse<IEvent>> {
     const response = await axios.get(`/events/${id}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -67,7 +67,7 @@ export async function createEvent(
     });
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -81,7 +81,7 @@ export async function approveEvent(
     });
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -96,7 +96,7 @@ export async function reactInterestedToEvent(
     const data = response.data as { interested: boolean };
     return successfulResponse(data.interested);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -111,7 +111,7 @@ export async function reactGoingToEvent(
     const data = response.data as { going: boolean };
     return successfulResponse(data.going);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -122,7 +122,7 @@ export async function getEventReactionsByPage(
     const response = await axios.get(`/events/reactions?page=${page}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -133,6 +133,6 @@ export async function getEventReactionsByEvent(
     const response = await axios.get(`/events/${eventId}/reactions`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }

--- a/client/src/gateways/GatewayResponses.ts
+++ b/client/src/gateways/GatewayResponses.ts
@@ -1,3 +1,5 @@
+import { AxiosError } from "axios";
+
 export type IResponse<T> = ISuccessfulResponse<T> | IFailureResponse;
 
 interface ISuccessfulResponse<T> {
@@ -12,7 +14,7 @@ interface IFailureResponse {
   success: false;
 }
 
-export function successfulResponse<T>(payload: T): IResponse<T> {
+export function successfulResponse<T>(payload: T): ISuccessfulResponse<T> {
   return {
     message: "OK",
     payload: payload,
@@ -20,10 +22,22 @@ export function successfulResponse<T>(payload: T): IResponse<T> {
   };
 }
 
-export function failureResponse<T>(message: string): IResponse<T> {
+export function failureResponse(message: string): IFailureResponse {
   return {
     message: message,
     payload: null,
     success: false,
   };
+}
+
+export function failureResponseFromError(error: unknown): IFailureResponse {
+  if (!(error instanceof AxiosError)) {
+    return failureResponse(error as string);
+  }
+  const axiosError = error as AxiosError;
+  let message = axiosError.message;
+  if (axiosError.response?.statusText) {
+    message += ` (${axiosError.response.statusText})`;
+  }
+  return failureResponse(message);
 }

--- a/client/src/gateways/PostGateway.ts
+++ b/client/src/gateways/PostGateway.ts
@@ -4,7 +4,7 @@ import IUser from "../types/IUser";
 import IComment from "../types/IComment";
 import IPost, { IPostReactions } from "../types/IPost";
 import {
-  failureResponse,
+  failureResponseFromError,
   IResponse,
   successfulResponse,
 } from "./GatewayResponses";
@@ -22,7 +22,7 @@ export async function getPosts(
     });
     return successfulResponse(response.data as IPost[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -34,7 +34,7 @@ export async function getAllPosts(page?: number): Promise<IResponse<IPost[]>> {
     });
     return successfulResponse(response.data as IPost[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -48,7 +48,7 @@ export async function getModFeedPosts(
     });
     return successfulResponse(response.data as IPost[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -62,7 +62,7 @@ export async function getModFeedComments(
     });
     return successfulResponse(response.data as IComment[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -71,7 +71,7 @@ export async function getPost(postNumber: number): Promise<IResponse<IPost>> {
     const response = await axios.get(`/posts/${postNumber}`);
     return successfulResponse(response.data as IPost);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -80,7 +80,7 @@ export async function createPost(content: string): Promise<IResponse<IPost>> {
     const response = await axios.post("/posts", { content });
     return successfulResponse(response.data as IPost);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -93,7 +93,7 @@ export async function createImagePost(
     const response = await axios.post("/posts/image", { title, imageUrl });
     return successfulResponse(response.data as IPost);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -110,7 +110,7 @@ export async function reactToPost(
     const data = response.data as { reaction: boolean };
     return successfulResponse(data.reaction);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -128,7 +128,7 @@ export async function commentOnPost(
     });
     return successfulResponse(response.data as IComment);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -149,7 +149,7 @@ export async function reactToComment(
     const data = response.data as { reaction: boolean };
     return successfulResponse(data.reaction);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -165,7 +165,7 @@ export async function approvePost(
     });
     return successfulResponse(response.data as IPost);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -181,7 +181,7 @@ export async function approveComment(
     );
     return successfulResponse(response.data as IPost);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -190,7 +190,7 @@ export async function searchPosts(query: string): Promise<IResponse<IPost[]>> {
     const response = await axios.get(`/posts/search?query=${query}`);
     return successfulResponse(response.data as IPost[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -205,7 +205,7 @@ export async function deleteComment(
     const data = response.data as { success: boolean };
     return successfulResponse(data.success);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -219,7 +219,7 @@ export async function bookmarkPost(
     });
     return successfulResponse(response.data as IUser);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -234,7 +234,7 @@ export async function subscribeToPost(
     const data = response.data as { subscribed: boolean };
     return successfulResponse(data.subscribed);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -247,7 +247,7 @@ export async function getPostReactionsByPage(
     });
     return successfulResponse(response.data as IPostReactions[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -258,7 +258,7 @@ export async function getPostReactionsByPost(
     const response = await axios.get(`/posts/${postNumber}/reactions`);
     return successfulResponse(response.data as IPostReactions);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -271,7 +271,7 @@ export async function getModFeedReports(
     });
     return successfulResponse(response.data as IReport[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -288,7 +288,7 @@ export async function flagComment(
     const data = response.data as { success: boolean };
     return successfulResponse(data.success);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -302,6 +302,6 @@ export async function resolveReport(
     );
     return successfulResponse(response.data as IReport);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }

--- a/client/src/gateways/PostGateway.ts
+++ b/client/src/gateways/PostGateway.ts
@@ -75,6 +75,15 @@ export async function getPost(postNumber: number): Promise<IResponse<IPost>> {
   }
 }
 
+export async function getPostById(postId: string): Promise<IResponse<IPost>> {
+  try {
+    const response = await axios.get(`/posts/id/${postId}`);
+    return successfulResponse(response.data as IPost);
+  } catch (error: unknown) {
+    return failureResponse(error as string);
+  }
+}
+
 export async function createPost(content: string): Promise<IResponse<IPost>> {
   try {
     const response = await axios.post("/posts", { content });

--- a/client/src/gateways/PostGateway.ts
+++ b/client/src/gateways/PostGateway.ts
@@ -80,7 +80,7 @@ export async function getPostById(postId: string): Promise<IResponse<IPost>> {
     const response = await axios.get(`/posts/id/${postId}`);
     return successfulResponse(response.data as IPost);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -322,6 +322,6 @@ export async function getAllPostNumbers(): Promise<
     const response = await axios.get(`/posts/numbers`);
     return successfulResponse(response.data as (number | string)[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }

--- a/client/src/gateways/PostGateway.ts
+++ b/client/src/gateways/PostGateway.ts
@@ -305,3 +305,14 @@ export async function resolveReport(
     return failureResponseFromError(error);
   }
 }
+
+export async function getAllPostNumbers(): Promise<
+  IResponse<(number | string)[]>
+> {
+  try {
+    const response = await axios.get(`/posts/numbers`);
+    return successfulResponse(response.data as (number | string)[]);
+  } catch (error: unknown) {
+    return failureResponse(error as string);
+  }
+}

--- a/client/src/gateways/UserGateway.ts
+++ b/client/src/gateways/UserGateway.ts
@@ -3,7 +3,7 @@ import IComment from "types/IComment";
 import IPost from "types/IPost";
 import IUser, { IBasicUser } from "../types/IUser";
 import {
-  failureResponse,
+  failureResponseFromError,
   IResponse,
   successfulResponse,
 } from "./GatewayResponses";
@@ -13,7 +13,7 @@ export async function getUser(_id: string): Promise<IResponse<IBasicUser>> {
     const response = await axios.get(`/user/${_id}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -24,7 +24,7 @@ export async function searchUsers(
     const response = await axios.get(`/user/search/${query}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -55,7 +55,7 @@ export async function updateUserProfile(
     });
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -68,7 +68,7 @@ export async function updateProfilePicture(
     });
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -83,7 +83,7 @@ export async function banUser(
     });
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -94,7 +94,7 @@ export async function getUserComments(
     const response = await axios.get(`/user/${_id}/comments`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -103,7 +103,7 @@ export async function getBookmarks(page: number): Promise<IResponse<IPost[]>> {
     const response = await axios.get(`/user/bookmarks?page=${page}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -114,7 +114,7 @@ export async function markNotificationAsRead(
     await axios.delete(`/user/notifications/${notificationId}`);
     return successfulResponse(true);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -125,7 +125,7 @@ export async function markAllNotificationsAsRead(): Promise<
     await axios.delete(`/user/notifications`);
     return successfulResponse(true);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -136,7 +136,7 @@ export async function updateSettings(
     const response = await axios.put(`/user/settings`, newSettings);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -145,7 +145,7 @@ export async function blockUser(_id: string): Promise<IResponse<IUser>> {
     const response = await axios.post(`/user/block`, { id: _id });
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -154,6 +154,6 @@ export async function unblockUser(_id: string): Promise<IResponse<IUser>> {
     const response = await axios.put(`/user/block`, { id: _id });
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }

--- a/client/src/pages/post/[id].tsx
+++ b/client/src/pages/post/[id].tsx
@@ -16,8 +16,6 @@ const PostPage: NextPage = () => {
   const router = useRouter();
   const id = String(router.query.id).trim();
   const postNumber = !isNaN(Number(id)) ? Number(id) : undefined;
-  console.log(`postNumber: "${postNumber ?? "undefined"}"`);
-  console.log(`id: "${id}"`);
 
   const { data, isLoading } = useQuery(["post", id], () =>
     postNumber ? getPost(postNumber) : getPostById(id)

--- a/client/src/pages/post/[id].tsx
+++ b/client/src/pages/post/[id].tsx
@@ -31,10 +31,20 @@ const PostPage: NextPage = () => {
     return <MainLayout />;
   }
 
+  const numReactions = post.reactions.reduce(
+    (acc, reaction) => acc + reaction.length,
+    0
+  );
+  const numComments = post.comments.length;
+
   return (
     <>
       <Head>
         <title>Post {post.postNumber} - Dear Blueno</title>
+        <meta name="post_number" content={post.postNumber.toString()} />
+        <meta name="date" content={post.approvedTime} />
+        <meta name="reactions_count" content={numReactions.toString()} />
+        <meta name="comments_count" content={numComments.toString()} />
       </Head>
       <MainLayout
         title={`Post #${post.postNumber}`}

--- a/client/src/pages/post/[id].tsx
+++ b/client/src/pages/post/[id].tsx
@@ -1,5 +1,5 @@
 import IPost from "../../types/IPost";
-import { getPost } from "../../gateways/PostGateway";
+import { getPost, getPostById } from "../../gateways/PostGateway";
 import Post from "components/post/Post";
 import NotFoundPage from "pages/404";
 import MainLayout from "components/layout/MainLayout";
@@ -14,21 +14,21 @@ import { useQuery } from "@tanstack/react-query";
 
 const PostPage: NextPage = () => {
   const router = useRouter();
-  const { id } = router.query;
-  const postNumber = id ? Number(id) : undefined;
-  const { data } = useQuery(["post", postNumber], () =>
-    postNumber ? getPost(postNumber) : undefined
-  );
+  const id = String(router.query.id).trim();
+  const postNumber = !isNaN(Number(id)) ? Number(id) : undefined;
+  console.log(`postNumber: "${postNumber ?? "undefined"}"`);
+  console.log(`id: "${id}"`);
 
-  if (!postNumber) {
-    return <MainLayout />;
-  }
-  if (isNaN(postNumber)) {
-    return <NotFoundPage />;
-  }
+  const { data, isLoading } = useQuery(["post", id], () =>
+    postNumber ? getPost(postNumber) : getPostById(id)
+  );
   const post = data?.success ? data.payload : undefined;
-  if (!post) {
+
+  if (isLoading) {
     return <MainLayout />;
+  }
+  if (!post) {
+    return <NotFoundPage />;
   }
 
   const numReactions = post.reactions.reduce(
@@ -40,14 +40,16 @@ const PostPage: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Post {post.postNumber} - Dear Blueno</title>
-        <meta name="post_number" content={post.postNumber.toString()} />
+        <title>Post {post.postNumber || post._id} - Dear Blueno</title>
+        {post.postNumber && (
+          <meta name="post_number" content={post.postNumber.toString()} />
+        )}
         <meta name="date" content={post.approvedTime} />
         <meta name="reactions_count" content={numReactions.toString()} />
         <meta name="comments_count" content={numComments.toString()} />
       </Head>
       <MainLayout
-        title={`Post #${post.postNumber}`}
+        title={`Post ${post.postNumber ? `#${post.postNumber}` : post._id}`}
         page={<PostPageMain post={post} />}
       />
     </>

--- a/client/src/pages/sitemap.txt.ts
+++ b/client/src/pages/sitemap.txt.ts
@@ -1,0 +1,28 @@
+import { GetServerSideProps } from "next";
+import { getAllPostNumbers } from "gateways/PostGateway";
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const response = await getAllPostNumbers();
+  if (!response.success) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const urls = response.payload.map(
+    (postNumber) => `https://www.dearblueno.net/post/${postNumber}`
+  );
+
+  const { res } = context;
+  res.setHeader("Content-Type", "text/plain");
+  res.write(urls.join("\n"));
+  res.end();
+
+  return {
+    props: {},
+  };
+};
+
+export default function SitemapTxt() {
+  return undefined;
+}

--- a/server/src/routes/posts.ts
+++ b/server/src/routes/posts.ts
@@ -203,6 +203,19 @@ postRouter.get(
   }
 );
 
+// GET request that returns a list of all post numbers
+postRouter.get("/numbers", async (_req, res) => {
+  const postNumbers = Post.find(
+    { approved: true, postNumber: { $ne: null } },
+    { postNumber: 1, _id: 0 }
+  );
+  const postIds = Post.find({ approved: true, postNumber: null }, { _id: 1 });
+  const posts = (await Promise.all([postNumbers, postIds])).flatMap((postArr) =>
+    postArr.map((post) => post.postNumber || post._id)
+  );
+  res.send(posts);
+});
+
 // GET request that gets a single post by id (only approved posts)
 postRouter.get(
   "/:id",

--- a/server/src/routes/posts.ts
+++ b/server/src/routes/posts.ts
@@ -216,14 +216,42 @@ postRouter.get("/numbers", async (_req, res) => {
   res.send(posts);
 });
 
-// GET request that gets a single post by id (only approved posts)
+// GET request that gets a single post by post number (only approved posts)
 postRouter.get(
-  "/:id",
+  "/:num",
   optionalAuth,
-  param("id").isInt({ min: 1 }),
+  param("num").isInt({ min: 1 }),
   validate,
   async (req, res) => {
-    const post = await Post.findOne({ postNumber: req.params.id })
+    const post = await Post.findOne({ postNumber: req.params.num })
+      .select("-approvedBy -subscribers -score -hotScore")
+      .populate("comments")
+      .populate({
+        path: "comments",
+        populate: {
+          path: "author",
+          select: "name profilePicture badges displayName pronouns",
+        },
+      });
+    if (!post || !post.approved) {
+      res.status(404).send("Post not found");
+      return;
+    }
+
+    const cleanPost = cleanSensitivePost(post.toObject(), req.user as IUser);
+
+    res.send(cleanPost);
+  }
+);
+
+// GET request that gets a single post by post id (only approved posts)
+postRouter.get(
+  "/id/:id",
+  optionalAuth,
+  param("id").isMongoId(),
+  validate,
+  async (req, res) => {
+    const post = await Post.findById(req.params.id)
       .select("-approvedBy -subscribers -score -hotScore")
       .populate("comments")
       .populate({
@@ -247,12 +275,12 @@ postRouter.get(
 // GET request that gets only the cleansed reactions of a single post
 // (Must be authenticated)
 postRouter.get(
-  "/:id/reactions",
+  "/:num/reactions",
   authCheck,
-  param("id").isInt({ min: 1 }),
+  param("num").isInt({ min: 1 }),
   validate,
   async (req, res) => {
-    const post = await Post.findOne({ postNumber: req.params.id })
+    const post = await Post.findOne({ postNumber: req.params.num })
       .select("reactions comments approved")
       .populate({
         path: "comments",
@@ -357,15 +385,15 @@ postRouter.put(
 // PUT request that reacts to a post
 // (Must be authenticated)
 postRouter.put(
-  "/:id/react",
+  "/:num/react",
   authCheck,
   body("reaction").isInt({ min: 1, max: 6 }),
   body("state").toBoolean(),
-  param("id").isInt({ min: 1 }),
+  param("num").isInt({ min: 1 }),
   validate,
   async (req, res) => {
     const post = await Post.findOne({
-      postNumber: Number(req.params.id),
+      postNumber: Number(req.params.num),
     });
     if (!post) {
       res.status(404).send("Post not found");
@@ -400,14 +428,14 @@ postRouter.put(
 // POST request that bookmarks a post
 // (Must be authenticated)
 postRouter.post(
-  "/:id/bookmark",
+  "/:num/bookmark",
   authCheck,
-  param("id").isInt({ min: 1 }),
+  param("num").isInt({ min: 1 }),
   body("bookmark").toBoolean(),
   validate,
   async (req, res) => {
     const post = await Post.findOne({
-      postNumber: Number(req.params.id),
+      postNumber: Number(req.params.num),
     });
     if (!post) {
       res.status(404).send("Post not found");
@@ -437,14 +465,14 @@ postRouter.post(
 // POST request that subscribes to a post (adds the post to a user's watchlist)
 // (Must be authenticated)
 postRouter.post(
-  "/:id/subscribe",
+  "/:num/subscribe",
   authCheck,
-  param("id").isInt({ min: 1 }),
+  param("num").isInt({ min: 1 }),
   body("subscribe").toBoolean(),
   validate,
   async (req, res) => {
     const post = await Post.findOne({
-      postNumber: Number(req.params.id),
+      postNumber: Number(req.params.num),
     });
     if (!post) {
       res.status(404).send("Post not found");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Title should be declarative and use present tense, e.g. "Add feature" not "Added feature" -->

## Description
<!--- Describe your changes in detail -->
* Adds a generated sitemap.txt containing a plain-text list of all the urls pointing to approved posts
* Updates the frontend post page to support taking _id as a param in addition to just post number
* Updates the frontend post page to add additional meta tags for boosting SEO
* Added backend endpoints for getting post by _id and getting all post numbers (as was necessary for above)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Should allow search engines to better index our posts
* Should allow us to consider switching to Google's Programmable Search Engine to replace our current search implementation (mongodb text index)

## Screenshots
<!--- If applicable, it is highly recommended to add screenshots! -->
<img width="413" alt="image" src="https://user-images.githubusercontent.com/13754214/230005965-87014be4-b204-434e-9e6c-057461d2a8a2.png">

## How this has been tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Added new backend integration tests for the two new endpoints.
* Tested post page with proper and malformed post params.
* Sitemap.txt route works with production dataset.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I ran the linter and formatter before submitting the PR. (`npm run lint`)
- [x] My PR passes all existing tests and adds new tests where appropriate. (`npm test`)
- [x] I have updated the documentation if necessary.
