### PR TITLE
Fix error message on failure gateway responses to be string

### DIFF
--- a/client/src/components/event/EventCard.tsx
+++ b/client/src/components/event/EventCard.tsx
@@ -129,7 +129,7 @@ export default function EventCard(props: EventCardProps) {
         }
       );
     } else {
-      toast.error((response.message as unknown as { message: string }).message);
+      toast.error(response.message);
     }
   };
 

--- a/client/src/components/post/Post.tsx
+++ b/client/src/components/post/Post.tsx
@@ -60,7 +60,7 @@ function Post(props: PostProps) {
       toast.success(`${action} #${props.post.postNumber}`);
       await refetchUser();
     } else {
-      toast.error((response.message as unknown as { message: string }).message);
+      toast.error(response.message);
       setIsSubscribed(!isSubscribed);
     }
   };
@@ -78,7 +78,7 @@ function Post(props: PostProps) {
       void queryClient.refetchQueries(["bookmarks"]);
       await refetchUser();
     } else {
-      toast.error((response.message as unknown as { message: string }).message);
+      toast.error(response.message);
       setIsBookmarked(initialIsBookmarked);
     }
   };

--- a/client/src/components/post/ReportReview.tsx
+++ b/client/src/components/post/ReportReview.tsx
@@ -44,7 +44,7 @@ export default function ReportReview(props: ReportReviewProps) {
         );
       }
     } else {
-      toast.error((response.message as unknown as { message: string }).message);
+      toast.error(response.message);
     }
   };
 

--- a/client/src/components/post/comments/ContextThread.tsx
+++ b/client/src/components/post/comments/ContextThread.tsx
@@ -39,7 +39,7 @@ function ContextThread(props: ContextThreadProps) {
         }
       );
     } else {
-      toast.error((response.message as unknown as { message: string }).message);
+      toast.error(response.message);
     }
   };
 

--- a/client/src/components/post/comments/comment_header/CommentMenuButton.tsx
+++ b/client/src/components/post/comments/comment_header/CommentMenuButton.tsx
@@ -116,10 +116,7 @@ function CommentMenuButton(props: CommentMenuButtonProps) {
                     if (response.success) {
                       toast.success("Comment reported");
                     } else {
-                      toast.error(
-                        (response.message as unknown as { message: string })
-                          .message
-                      );
+                      toast.error(response.message);
                       console.log(response);
                     }
                     closePopup();

--- a/client/src/components/post/comments/new_comment/NewCommentBox.tsx
+++ b/client/src/components/post/comments/new_comment/NewCommentBox.tsx
@@ -81,9 +81,7 @@ function NewCommentBox(props: NewCommentBoxProps) {
           });
           return true;
         }
-        toast.error(
-          (response.message as unknown as { message: string }).message
-        );
+        toast.error(response.message);
         return false;
       }
       return false;

--- a/client/src/components/post/moderator/ApproveOrDeny.tsx
+++ b/client/src/components/post/moderator/ApproveOrDeny.tsx
@@ -53,9 +53,7 @@ function ApproveOrDeny(props: ApproveOrDenyProps) {
               }
             );
           } else {
-            toast.error(
-              (response.message as unknown as { message: string }).message
-            );
+            toast.error(response.message);
           }
         };
       case "comment":
@@ -86,9 +84,7 @@ function ApproveOrDeny(props: ApproveOrDenyProps) {
               }
             );
           } else {
-            toast.error(
-              (response.message as unknown as { message: string }).message
-            );
+            toast.error(response.message);
           }
         };
     }

--- a/client/src/components/post/moderator/CommentReview.tsx
+++ b/client/src/components/post/moderator/CommentReview.tsx
@@ -34,7 +34,7 @@ function CommentReview(props: CommentReviewProps) {
         }
       );
     } else {
-      toast.error((response.message as unknown as { message: string }).message);
+      toast.error(response.message);
     }
   };
 

--- a/client/src/components/post/reactions/ReactionButton.tsx
+++ b/client/src/components/post/reactions/ReactionButton.tsx
@@ -32,9 +32,7 @@ function ReactionButton(props: ReactionButtonProps) {
             result
               .then((response) => {
                 if (!response.success) {
-                  toast.error(
-                    (response.message as unknown as { message: string }).message
-                  );
+                  toast.error(response.message);
                 }
               })
               .catch(() => toast.error("Uh oh, something went wrong"));

--- a/client/src/components/profile/ProfileBox.tsx
+++ b/client/src/components/profile/ProfileBox.tsx
@@ -158,9 +158,7 @@ function ProfileBox(props: ProfileBoxProps) {
               console.error(error);
             });
         } else {
-          toast.error(
-            (response.message as unknown as { message: string }).message
-          );
+          toast.error(response.message);
         }
       })
       .catch((error) => {

--- a/client/src/components/submit/ImageSubmit.tsx
+++ b/client/src/components/submit/ImageSubmit.tsx
@@ -29,9 +29,7 @@ function ImageSubmit(props: ImageSubmitProps) {
           props.setSubmitted(true);
           toast.success("Post submitted for approval!");
         } else {
-          toast.error(
-            (response.message as unknown as { message: string }).message
-          );
+          toast.error(response.message);
         }
       })
       .catch((error) => {

--- a/client/src/components/submit/TextSubmit.tsx
+++ b/client/src/components/submit/TextSubmit.tsx
@@ -22,9 +22,7 @@ function TextSubmit(props: TextSubmitProps) {
           props.setSubmitted(true);
           toast.success("Post submitted for approval!");
         } else {
-          toast.error(
-            (response.message as unknown as { message: string }).message
-          );
+          toast.error(response.message);
         }
       })
       .catch((error) => {

--- a/client/src/gateways/AuthGateway.ts
+++ b/client/src/gateways/AuthGateway.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import IUser from "../types/IUser";
 import {
   failureResponse,
+  failureResponseFromError,
   IResponse,
   successfulResponse,
 } from "./GatewayResponses";
@@ -17,7 +18,7 @@ export async function loadAuth(): Promise<IResponse<IUser>> {
       return failureResponse("Not logged in");
     }
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 

--- a/client/src/gateways/EventGateway.ts
+++ b/client/src/gateways/EventGateway.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import IEvent, { IEventReactions } from "../types/IEvent";
 import {
-  failureResponse,
+  failureResponseFromError,
   IResponse,
   successfulResponse,
 } from "./GatewayResponses";
@@ -11,7 +11,7 @@ export async function getEvents(page: number): Promise<IResponse<IEvent[]>> {
     const response = await axios.get(`/events?page=${page}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -21,7 +21,7 @@ export async function getAllEvents(page: number): Promise<IResponse<IEvent[]>> {
     const response = await axios.get(`/events/all?page=${page}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -33,7 +33,7 @@ export async function getModFeedEvents(
     const response = await axios.get(`/events/mod-feed?page=${page}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -42,7 +42,7 @@ export async function getEvent(id: string): Promise<IResponse<IEvent>> {
     const response = await axios.get(`/events/${id}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -67,7 +67,7 @@ export async function createEvent(
     });
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -81,7 +81,7 @@ export async function approveEvent(
     });
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -96,7 +96,7 @@ export async function reactInterestedToEvent(
     const data = response.data as { interested: boolean };
     return successfulResponse(data.interested);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -111,7 +111,7 @@ export async function reactGoingToEvent(
     const data = response.data as { going: boolean };
     return successfulResponse(data.going);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -122,7 +122,7 @@ export async function getEventReactionsByPage(
     const response = await axios.get(`/events/reactions?page=${page}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -133,6 +133,6 @@ export async function getEventReactionsByEvent(
     const response = await axios.get(`/events/${eventId}/reactions`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }

--- a/client/src/gateways/GatewayResponses.ts
+++ b/client/src/gateways/GatewayResponses.ts
@@ -1,3 +1,5 @@
+import { AxiosError } from "axios";
+
 export type IResponse<T> = ISuccessfulResponse<T> | IFailureResponse;
 
 interface ISuccessfulResponse<T> {
@@ -12,7 +14,7 @@ interface IFailureResponse {
   success: false;
 }
 
-export function successfulResponse<T>(payload: T): IResponse<T> {
+export function successfulResponse<T>(payload: T): ISuccessfulResponse<T> {
   return {
     message: "OK",
     payload: payload,
@@ -20,10 +22,22 @@ export function successfulResponse<T>(payload: T): IResponse<T> {
   };
 }
 
-export function failureResponse<T>(message: string): IResponse<T> {
+export function failureResponse(message: string): IFailureResponse {
   return {
     message: message,
     payload: null,
     success: false,
   };
+}
+
+export function failureResponseFromError(error: unknown): IFailureResponse {
+  if (!(error instanceof AxiosError)) {
+    return failureResponse(error as string);
+  }
+  const axiosError = error as AxiosError;
+  let message = axiosError.message;
+  if (axiosError.response) {
+    message += ` (${axiosError.response.statusText})`;
+  }
+  return failureResponse(message);
 }

--- a/client/src/gateways/GatewayResponses.ts
+++ b/client/src/gateways/GatewayResponses.ts
@@ -36,7 +36,7 @@ export function failureResponseFromError(error: unknown): IFailureResponse {
   }
   const axiosError = error as AxiosError;
   let message = axiosError.message;
-  if (axiosError.response) {
+  if (axiosError.response?.statusText) {
     message += ` (${axiosError.response.statusText})`;
   }
   return failureResponse(message);

--- a/client/src/gateways/PostGateway.ts
+++ b/client/src/gateways/PostGateway.ts
@@ -4,7 +4,7 @@ import IUser from "../types/IUser";
 import IComment from "../types/IComment";
 import IPost, { IPostReactions } from "../types/IPost";
 import {
-  failureResponse,
+  failureResponseFromError,
   IResponse,
   successfulResponse,
 } from "./GatewayResponses";
@@ -22,7 +22,7 @@ export async function getPosts(
     });
     return successfulResponse(response.data as IPost[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -34,7 +34,7 @@ export async function getAllPosts(page?: number): Promise<IResponse<IPost[]>> {
     });
     return successfulResponse(response.data as IPost[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -48,7 +48,7 @@ export async function getModFeedPosts(
     });
     return successfulResponse(response.data as IPost[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -62,7 +62,7 @@ export async function getModFeedComments(
     });
     return successfulResponse(response.data as IComment[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -71,7 +71,7 @@ export async function getPost(postNumber: number): Promise<IResponse<IPost>> {
     const response = await axios.get(`/posts/${postNumber}`);
     return successfulResponse(response.data as IPost);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -80,7 +80,7 @@ export async function createPost(content: string): Promise<IResponse<IPost>> {
     const response = await axios.post("/posts", { content });
     return successfulResponse(response.data as IPost);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -93,7 +93,7 @@ export async function createImagePost(
     const response = await axios.post("/posts/image", { title, imageUrl });
     return successfulResponse(response.data as IPost);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -110,7 +110,7 @@ export async function reactToPost(
     const data = response.data as { reaction: boolean };
     return successfulResponse(data.reaction);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -128,7 +128,7 @@ export async function commentOnPost(
     });
     return successfulResponse(response.data as IComment);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -149,7 +149,7 @@ export async function reactToComment(
     const data = response.data as { reaction: boolean };
     return successfulResponse(data.reaction);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -165,7 +165,7 @@ export async function approvePost(
     });
     return successfulResponse(response.data as IPost);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -181,7 +181,7 @@ export async function approveComment(
     );
     return successfulResponse(response.data as IPost);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -190,7 +190,7 @@ export async function searchPosts(query: string): Promise<IResponse<IPost[]>> {
     const response = await axios.get(`/posts/search?query=${query}`);
     return successfulResponse(response.data as IPost[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -205,7 +205,7 @@ export async function deleteComment(
     const data = response.data as { success: boolean };
     return successfulResponse(data.success);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -219,7 +219,7 @@ export async function bookmarkPost(
     });
     return successfulResponse(response.data as IUser);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -234,7 +234,7 @@ export async function subscribeToPost(
     const data = response.data as { subscribed: boolean };
     return successfulResponse(data.subscribed);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -247,7 +247,7 @@ export async function getPostReactionsByPage(
     });
     return successfulResponse(response.data as IPostReactions[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -258,7 +258,7 @@ export async function getPostReactionsByPost(
     const response = await axios.get(`/posts/${postNumber}/reactions`);
     return successfulResponse(response.data as IPostReactions);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -271,7 +271,7 @@ export async function getModFeedReports(
     });
     return successfulResponse(response.data as IReport[]);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -288,7 +288,7 @@ export async function flagComment(
     const data = response.data as { success: boolean };
     return successfulResponse(data.success);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -302,6 +302,6 @@ export async function resolveReport(
     );
     return successfulResponse(response.data as IReport);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }

--- a/client/src/gateways/UserGateway.ts
+++ b/client/src/gateways/UserGateway.ts
@@ -3,7 +3,7 @@ import IComment from "types/IComment";
 import IPost from "types/IPost";
 import IUser, { IBasicUser } from "../types/IUser";
 import {
-  failureResponse,
+  failureResponseFromError,
   IResponse,
   successfulResponse,
 } from "./GatewayResponses";
@@ -13,7 +13,7 @@ export async function getUser(_id: string): Promise<IResponse<IBasicUser>> {
     const response = await axios.get(`/user/${_id}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -24,7 +24,7 @@ export async function searchUsers(
     const response = await axios.get(`/user/search/${query}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -55,7 +55,7 @@ export async function updateUserProfile(
     });
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -68,7 +68,7 @@ export async function updateProfilePicture(
     });
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -83,7 +83,7 @@ export async function banUser(
     });
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -94,7 +94,7 @@ export async function getUserComments(
     const response = await axios.get(`/user/${_id}/comments`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -103,7 +103,7 @@ export async function getBookmarks(page: number): Promise<IResponse<IPost[]>> {
     const response = await axios.get(`/user/bookmarks?page=${page}`);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -114,7 +114,7 @@ export async function markNotificationAsRead(
     await axios.delete(`/user/notifications/${notificationId}`);
     return successfulResponse(true);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -125,7 +125,7 @@ export async function markAllNotificationsAsRead(): Promise<
     await axios.delete(`/user/notifications`);
     return successfulResponse(true);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -136,7 +136,7 @@ export async function updateSettings(
     const response = await axios.put(`/user/settings`, newSettings);
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -145,7 +145,7 @@ export async function blockUser(_id: string): Promise<IResponse<IUser>> {
     const response = await axios.post(`/user/block`, { id: _id });
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }
 
@@ -154,6 +154,6 @@ export async function unblockUser(_id: string): Promise<IResponse<IUser>> {
     const response = await axios.put(`/user/block`, { id: _id });
     return successfulResponse(response.data);
   } catch (error: unknown) {
-    return failureResponse(error as string);
+    return failureResponseFromError(error);
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Title should be declarative and use present tense, e.g. "Add feature" not "Added feature" -->

## Description
<!--- Describe your changes in detail -->
* The IFailureResponse gateway response interface is supposed to contain a string `message`. Up to this point, the `message` value has actually been an `AxiosError` object, meaning the type contract was lying. This PR fixes that contract to actually return a proper string with the error message pulled from the `AxiosError`.
* Reduced some repetitive code found in the toast error notifications.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Improved code quality

## Screenshots
<!--- If applicable, it is highly recommended to add screenshots! -->
<img width="206" alt="image" src="https://user-images.githubusercontent.com/13754214/230012751-0a6edd23-d7ec-4dc5-b903-90ad9aa741d7.png"><img width="406" alt="image" src="https://user-images.githubusercontent.com/13754214/230013108-f82514c3-b114-41d9-a30a-ae630caf538a.png">


## How this has been tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Works with NetworkErrors and AxiosErrors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] QOL/Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I ran the linter and formatter before submitting the PR. (`npm run lint`)
- [x] My PR passes all existing tests and adds new tests where appropriate. (`npm test`)
- [x] I have updated the documentation if necessary.
