### PR TITLE
fix formatting of multiday events

### DIFF
--- a/client/src/components/event/EventCard.tsx
+++ b/client/src/components/event/EventCard.tsx
@@ -47,6 +47,14 @@ export default function EventCard(props: EventCardProps) {
       "yyyy-MM-dd"
     )
   );
+  const endDate = makeDate(
+    formatInTimeZone(
+      new Date(props.event.endDate),
+      "America/New_York",
+      "yyyy-MM-dd"
+    )
+  );
+  const multiDay = startDate !== endDate;
 
   const queryClient = useQueryClient();
 
@@ -163,9 +171,15 @@ export default function EventCard(props: EventCardProps) {
         <Linkify tagName="p" className={styles.EventLocation}>
           {props.event.location}
         </Linkify>
-        <p>
-          {startDate} • {startTime} - {endTime} ET
-        </p>
+        {!multiDay ? (
+          <p>
+            {startDate} • {startTime} - {endTime} ET
+          </p>
+        ) : (
+          <p>
+            {startDate} • {startTime} - {endDate} • {endTime} ET
+          </p>
+        )}
         <div className={styles.AttendeeContainer}>
           <div className={styles.EventCardAttendees}>
             <p>{props.event.going.length}</p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Title should be declarative and use present tense, e.g. "Add feature" not "Added feature" -->

<!--- Describe your changes in detail -->
Added formatting for multiday events by rendering both start date and end date in the case where they are not equal.

<img width="733" alt="image" src="https://user-images.githubusercontent.com/77805275/235553971-8770fb58-0ba5-4a7e-bd8b-60a5205d8d8d.png">

